### PR TITLE
[WebServer.java] close opened file descriptors properly

### DIFF
--- a/src/main/java/org/havenapp/main/service/WebServer.java
+++ b/src/main/java/org/havenapp/main/service/WebServer.java
@@ -79,6 +79,7 @@ public class WebServer extends NanoHTTPD {
                 File fileMedia = new File(eventTrigger.getPath());
                 FileInputStream fis = new FileInputStream(fileMedia);
                 Response res = newChunkedResponse(Response.Status.OK, getMimeType(eventTrigger), fis);
+                fis.close();
                 return res;
 
             }


### PR DESCRIPTION
🐛 label: resource-leak

Greetings,

Calling `fis.close();` here will ensure here will ensure the file descriptor is properly disposed of and we will not run out of resources for more files. Even if it's closed automatically by the system when exiting the process, we believe you should release `fis` when done with it.

Signed-off-by: Bryon Gloden, CISSP® <cissp@bryongloden.com>