### PR TITLE
Don't automatically back up app settings @ Google

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -15,10 +15,12 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
-    <application
+    <application  xmlns:tools="http://schemas.android.com/tools"
         android:name="org.havenapp.main.HavenApp"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        tools:replace="android:allowBackup"
+        android:allowBackup="false"
         android:theme="@style/AppTheme">
         <activity
             android:name="org.havenapp.main.ListActivity"


### PR DESCRIPTION
I believe this should block app settings from being synced to Google.  See:

https://developer.android.com/guide/topics/data/autobackup.html

Note I've only tried with the newer project stuff I made in pr #67 

The "tools:replace" line was necessary because I guess one of the used libraries had set it as well.

