### PR TITLE
Capitalize GitHub in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can currently get the Haven BETA release in one of three ways:
 
 or add this repository manually in F-Droid's Settings->Repositories: [https://guardianproject.github.io/haven-nightly/fdroid/repo/](https://guardianproject.github.io/haven-nightly/fdroid/repo/)
 
-* Grab the APK files from the [Github releases page](https://github.com/guardianproject/haven/releases)
+* Grab the APK files from the [GitHub releases page](https://github.com/guardianproject/haven/releases)
 
 You can, of course, build the app yourself, from source.
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
       <h1 class="project-name"><img src="https://raw.githubusercontent.com/guardianproject/haven/master/fastlane/android/metadata/en-US/images/icon.png" style="height:96px;vertical-align: middle"/><br/>{{ site.title | default: site.github.repository_name }}</h1>
       <h2 class="project-tagline">{{ site.description | default: site.github.project_tagline }}</h2>
       {% if site.github.is_project_page %}
-        <a href="{{ site.github.repository_url }}" class="btn">View Github</a>
+        <a href="{{ site.github.repository_url }}" class="btn">View GitHub</a>
 	<a href="#install" class="btn">Install Beta</a>
         <a href="https://freedom.press/donate-support-haven-open-source-project/" class="btn">Donate Funds</a>
         <a href="https://guardianproject.info/contact/" class="btn">Contact Us</a>


### PR DESCRIPTION
A tiny stylistic fix.