### PR TITLE
Show onboarding only on first launch

### DIFF
--- a/src/main/java/org/havenapp/main/ListActivity.java
+++ b/src/main/java/org/havenapp/main/ListActivity.java
@@ -67,6 +67,7 @@ public class ListActivity extends AppCompatActivity {
     Toolbar toolbar;
     EventAdapter adapter;
     List<Event> events = new ArrayList<>();
+    PreferenceManager preferences;
 
     long initialCount;
 
@@ -83,6 +84,7 @@ public class ListActivity extends AppCompatActivity {
         setContentView(R.layout.activity_list);
         Log.d("Main", "onCreate");
 
+        preferences = new PreferenceManager(this.getApplicationContext());
         recyclerView = (RecyclerView) findViewById(R.id.main_list);
         fab = (FloatingActionButton) findViewById(R.id.fab);
         toolbar = (Toolbar) findViewById(R.id.toolbar);
@@ -146,18 +148,18 @@ public class ListActivity extends AppCompatActivity {
 
         initialCount = Event.count(Event.class);
 
-        if (initialCount <= 0) {
+        if (preferences.isFirstLaunch()) {
+            showOnboarding();
+        }
 
-           showOnboarding();
-
-        } else {
-            recyclerView.setVisibility(View.VISIBLE);
+        if (initialCount > 0) {
             findViewById(R.id.empty_view).setVisibility(View.GONE);
         }
 
         try {
             events = Event.listAll(Event.class, "id DESC");
             adapter = new EventAdapter(ListActivity.this, events);
+            recyclerView.setVisibility(View.VISIBLE);
             recyclerView.setAdapter(adapter);
 
 
@@ -224,6 +226,7 @@ public class ListActivity extends AppCompatActivity {
 
         if (requestCode == REQUEST_CODE_INTRO)
         {
+            preferences.setFirstLaunch(false);
             Intent i = new Intent(ListActivity.this, MonitorActivity.class);
             startActivity(i);
         }

--- a/src/main/java/org/havenapp/main/PreferenceManager.java
+++ b/src/main/java/org/havenapp/main/PreferenceManager.java
@@ -65,6 +65,8 @@ public class PreferenceManager {
 
     private static final String SIGNAL_USERNAME = "signal_username";
 
+    private static final String FIRST_LAUNCH = "first_launch";
+
 
     private Context context;
 	
@@ -72,6 +74,15 @@ public class PreferenceManager {
         this.context = context;
         this.appSharedPrefs = context.getSharedPreferences(APP_SHARED_PREFS, Activity.MODE_PRIVATE);
         this.prefsEditor = appSharedPrefs.edit();
+    }
+
+    public boolean isFirstLaunch() {
+        return appSharedPrefs.getBoolean(FIRST_LAUNCH, true);
+    }
+
+    public void setFirstLaunch(boolean firstLaunch) {
+        prefsEditor.putBoolean(FIRST_LAUNCH, firstLaunch);
+        prefsEditor.commit();
     }
 
     public String getSignalUsername ()


### PR DESCRIPTION
Before this change, the app will show the onboarding intro on every launch if there are no saved events, regardless of how much the user has used the app before. A user might be regular user of Haven but in the habit of clearing his logs at the end of every day/week/month, and would have to go through the intro every time afterwards.

Since there is already a way to access the intro from the overflow menu in the list activity, it makes sense to have the intro launch automatically only on first launch.