### PR TITLE
Slider changes to fix #108 and betterize the slider behavior generally

### DIFF
--- a/src/main/java/org/havenapp/main/ui/AccelConfigureActivity.java
+++ b/src/main/java/org/havenapp/main/ui/AccelConfigureActivity.java
@@ -44,6 +44,8 @@ public class AccelConfigureActivity extends AppCompatActivity implements SensorE
     private SimpleWaveformExtended mWaveform;
     private LinkedList<Integer> mWaveAmpList;
 
+    static final int MAX_SLIDER_VALUE = 100;
+
     private double maxAmp = 0;
 
     /**
@@ -90,9 +92,10 @@ public class AccelConfigureActivity extends AppCompatActivity implements SensorE
         mTextLevel = (TextView)findViewById(R.id.text_display_level);
         mNumberTrigger = (ActualNumberPicker)findViewById(R.id.number_trigger_level);
         mWaveform = (SimpleWaveformExtended)findViewById(R.id.simplewaveform);
+        mWaveform.setMaxVal(MAX_SLIDER_VALUE);
 
         mNumberTrigger.setMinValue(0);
-        mNumberTrigger.setMaxValue(100);
+        mNumberTrigger.setMaxValue(MAX_SLIDER_VALUE);
         mNumberTrigger.setListener(new OnValueChangeListener() {
             @Override
             public void onValueChanged(int oldValue, int newValue) {

--- a/src/main/java/org/havenapp/main/ui/MicrophoneConfigureActivity.java
+++ b/src/main/java/org/havenapp/main/ui/MicrophoneConfigureActivity.java
@@ -35,6 +35,7 @@ public class MicrophoneConfigureActivity extends AppCompatActivity implements Mi
     private PreferenceManager mPrefManager;
     private SimpleWaveformExtended mWaveform;
     private LinkedList<Integer> mWaveAmpList;
+    static final int MAX_SLIDER_VALUE = 120;
 
     private double maxAmp = 0;
 
@@ -52,9 +53,10 @@ public class MicrophoneConfigureActivity extends AppCompatActivity implements Mi
         mTextLevel = (TextView)findViewById(R.id.text_display_level);
         mNumberTrigger = (ActualNumberPicker)findViewById(R.id.number_trigger_level);
         mWaveform = (SimpleWaveformExtended)findViewById(R.id.simplewaveform);
+        mWaveform.setMaxVal(MAX_SLIDER_VALUE);
 
         mNumberTrigger.setMinValue(0);
-        mNumberTrigger.setMaxValue(120);
+        mNumberTrigger.setMaxValue(MAX_SLIDER_VALUE);
         mNumberTrigger.setListener(new OnValueChangeListener() {
             @Override
             public void onValueChanged(int oldValue, int newValue) {

--- a/src/main/java/org/havenapp/main/ui/SimpleWaveformExtended.java
+++ b/src/main/java/org/havenapp/main/ui/SimpleWaveformExtended.java
@@ -14,6 +14,8 @@ public class SimpleWaveformExtended extends SimpleWaveform {
 
 
     private int mThreshold = 0;
+    int lineY;
+    int maxVal = 100; // default max value of slider
 
     public SimpleWaveformExtended(Context context) {
         super(context);
@@ -21,6 +23,10 @@ public class SimpleWaveformExtended extends SimpleWaveform {
 
     public SimpleWaveformExtended(Context context, AttributeSet attrs) {
         super(context, attrs);
+    }
+
+    public void setMaxVal(int max_val) {
+        this.maxVal = max_val;
     }
 
     public void setThreshold (int threshold)
@@ -31,9 +37,8 @@ public class SimpleWaveformExtended extends SimpleWaveform {
     @Override
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
-
-        float percDb = (((float)mThreshold)/120f)*100f;
-        int lineY = getHeight()/2-(int)percDb*4;
+        int midY = getHeight()/2;
+        lineY =  midY - (int) (((float) mThreshold/ maxVal) * midY);
         canvas.drawLine(0,lineY,getWidth(),lineY,peakPencilFirst);
     }
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -109,7 +109,7 @@
     <string name="current_noise_base">Current noise level is</string>
     <string name="current_accel_base">Current motion level is</string>
 
-    <string name="configure_trigger_level">Slide wheel to change detection threshold</string>
+    <string name="configure_trigger_level">Slide to set detection threshold</string>
     <string name="tune_the_sound_detection">Make some noise!</string>
     <string name="set_your_phone_on_the_table_and_make_noises_in_the_room_to_find_the_right_level_to_detect">Set your phone on the table, and make noises in the room to find the right level to detect</string>
 


### PR DESCRIPTION
This allows you to set the WaveForm to match the maximum slider value so that it can be from
0->whatever (the accelerometer currently uses 100 but the mic uses 120 as the max).  It also changes the text to eliminate the "wheel" verbiage which I thought was a bit confusing.  And the scaling of the yellow line is maybe a little simpler and won't scroll off the top w/the mic setting.

As always, please test before committing.  I've only built this with my project/tools update in #67 but
seems to work okay..