### PR TITLE
Keep app name untranslatable

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
 
-    <string name="app_name">Haven</string>
+    <string name="app_name" translatable="false">Haven</string>
 
     <string name="menu_stop">Stop</string>
     <string name="menu_start">Start</string>


### PR DESCRIPTION
As news travels the world people will search for the app "Haven", having this translated might make it difficult to find.
