### PR TITLE
Hide the service notification from secure lockscreen

### DIFF
--- a/src/main/java/org/havenapp/main/service/MonitorService.java
+++ b/src/main/java/org/havenapp/main/service/MonitorService.java
@@ -192,6 +192,7 @@ public class MonitorService extends Service {
 		mBuilder.setPriority(NotificationCompat.PRIORITY_MIN);
         mBuilder.setContentIntent(resultPendingIntent);
         mBuilder.setWhen(System.currentTimeMillis());
+        mBuilder.setVisibility(NotificationCompat.VISIBILITY_SECRET);
 
 		startForeground(1, mBuilder.build());
 


### PR DESCRIPTION
Hide the notification from the lockscreen, so it's not obvious to others that you are running this app (works only if you have a pin or fingerprint set up)