### PR TITLE
Monitor significant motion with BumpMonitor

### DIFF
--- a/src/main/java/org/havenapp/main/model/EventTrigger.java
+++ b/src/main/java/org/havenapp/main/model/EventTrigger.java
@@ -49,6 +49,10 @@ public class EventTrigger extends SugarRecord {
      * Power change detected message
      */
     public static final int POWER = 4;
+    /**
+     * Significant motion detected message
+     */
+    public static final int BUMP = 5;
 
 
     public EventTrigger ()
@@ -104,6 +108,9 @@ public class EventTrigger extends SugarRecord {
                 break;
             case EventTrigger.POWER:
                 sType = context.getString(R.string.sensor_power);
+                break;
+            case EventTrigger.BUMP:
+                sType = context.getString(R.string.sensor_bump);
                 break;
             default:
                 sType = context.getString(R.string.sensor_unknown);

--- a/src/main/java/org/havenapp/main/sensors/BumpMonitor.java
+++ b/src/main/java/org/havenapp/main/sensors/BumpMonitor.java
@@ -1,0 +1,120 @@
+package org.havenapp.main.sensors;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.hardware.Sensor;
+import android.hardware.SensorManager;
+import android.hardware.TriggerEvent;
+import android.hardware.TriggerEventListener;
+import android.os.IBinder;
+import android.os.Message;
+import android.os.Messenger;
+import android.os.RemoteException;
+import android.util.Log;
+
+import org.havenapp.main.model.EventTrigger;
+import org.havenapp.main.service.MonitorService;
+
+/**
+ * Use the Significant Motion trigger sensor on API 18+
+ *
+ * Created by rockgecko on 27/12/17.
+ */
+@TargetApi(18)
+public class BumpMonitor {
+
+    // For shake motion detection.
+    private SensorManager sensorMgr;
+
+    /**
+     * Accelerometer sensor
+     */
+    private Sensor bumpSensor;
+
+    /**
+     * Last update of the accelerometer
+     */
+    private long lastUpdate = -1;
+
+
+    private final static int CHECK_INTERVAL = 1000;
+
+    public BumpMonitor(Context context) {
+
+
+        context.bindService(new Intent(context,
+                MonitorService.class), mConnection, Context.BIND_ABOVE_CLIENT);
+
+        sensorMgr = (SensorManager) context.getSystemService(Activity.SENSOR_SERVICE);
+        bumpSensor = sensorMgr.getDefaultSensor(Sensor.TYPE_SIGNIFICANT_MOTION);
+
+        if (bumpSensor == null) {
+            Log.i("BumpMonitor", "Warning: no significant motion sensor");
+        } else {
+            boolean registered = sensorMgr.requestTriggerSensor(sensorListener, bumpSensor);
+            Log.i("BumpMonitor", "Significant motion sensor registered: "+registered);
+        }
+
+    }
+
+
+    public void stop(Context context) {
+        sensorMgr.cancelTriggerSensor(sensorListener, bumpSensor);
+        context.unbindService(mConnection);
+    }
+    private TriggerEventListener sensorListener = new TriggerEventListener() {
+        @Override
+        public void onTrigger(TriggerEvent event) {
+            Log.i("BumpMonitor", "Sensor triggered");
+            //value[0] = 1.0 when the sensor triggers. 1.0 is the only allowed value.
+            long curTime = System.currentTimeMillis();
+            // only allow one update every 100ms.
+            if (event.sensor.getType() == Sensor.TYPE_SIGNIFICANT_MOTION) {
+                if ((curTime - lastUpdate) > CHECK_INTERVAL) {
+                    lastUpdate = curTime;
+
+                    /*
+                     * Send Alert
+                     */
+                    Message message = new Message();
+                    message.what = EventTrigger.BUMP;
+
+                    try {
+                        if (serviceMessenger != null) {
+                            serviceMessenger.send(message);
+                        }
+                    } catch (RemoteException e) {
+                        // TODO Auto-generated catch block
+                        e.printStackTrace();
+                    }
+                }
+            }
+            //re-register the listener (it finishes after each event)
+            boolean registered = sensorMgr.requestTriggerSensor(sensorListener, bumpSensor);
+            Log.i("BumpMonitor", "Significant motion sensor re-registered: "+registered);
+
+        }
+    };
+
+    private Messenger serviceMessenger = null;
+
+    private ServiceConnection mConnection = new ServiceConnection() {
+
+        public void onServiceConnected(ComponentName className,
+                                       IBinder service) {
+            Log.i("BumpMonitor", "SERVICE CONNECTED");
+            // We've bound to LocalService, cast the IBinder and get LocalService instance
+            serviceMessenger = new Messenger(service);
+        }
+
+        public void onServiceDisconnected(ComponentName arg0) {
+            Log.i("BumpMonitor", "SERVICE DISCONNECTED");
+            serviceMessenger = null;
+        }
+    };
+
+}

--- a/src/main/java/org/havenapp/main/service/MonitorService.java
+++ b/src/main/java/org/havenapp/main/service/MonitorService.java
@@ -15,6 +15,7 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Message;
@@ -38,6 +39,7 @@ import org.havenapp.main.model.EventTrigger;
 import org.havenapp.main.sensors.AccelerometerMonitor;
 import org.havenapp.main.sensors.AmbientLightMonitor;
 import org.havenapp.main.sensors.BarometerMonitor;
+import org.havenapp.main.sensors.BumpMonitor;
 import org.havenapp.main.sensors.MicrophoneMonitor;
 
 @SuppressLint("HandlerLeak")
@@ -73,6 +75,7 @@ public class MonitorService extends Service {
      * Sensor Monitors
      */
     AccelerometerMonitor mAccelManager = null;
+    BumpMonitor mBumpMonitor = null;
     MicrophoneMonitor mMicMonitor = null;
     BarometerMonitor mBaroMonitor = null;
     AmbientLightMonitor mLightMonitor = null;
@@ -209,6 +212,9 @@ public class MonitorService extends Service {
 
         if (mPrefs.getAccelerometerSensitivity() != PreferenceManager.OFF) {
             mAccelManager = new AccelerometerMonitor(this);
+            if(Build.VERSION.SDK_INT>=18) {
+                mBumpMonitor = new BumpMonitor(this);
+            }
             mBaroMonitor = new BarometerMonitor(this);
             mLightMonitor = new AmbientLightMonitor(this);
         }
@@ -222,9 +228,14 @@ public class MonitorService extends Service {
     private void stopSensors ()
     {
         mIsRunning = false;
-
+        //this will never be false:
+        // -you can't use ==, != for string comparisons, use equals() instead
+        // -Value is never set to OFF in the first place
         if (mPrefs.getAccelerometerSensitivity() != PreferenceManager.OFF) {
             mAccelManager.stop(this);
+            if(Build.VERSION.SDK_INT>=18) {
+                mBumpMonitor.stop(this);
+            }
             mBaroMonitor.stop(this);
             mLightMonitor.stop(this);
         }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -150,5 +150,6 @@
     <string name="sensor_camera">Motion (Camera)</string>
     <string name="sensor_sound">Microphone</string>
     <string name="sensor_power">USB Power</string>
+    <string name="sensor_bump">Bump (Accelerometer)</string>
     <string name="sensor_unknown">Unknown</string>
 </resources>


### PR DESCRIPTION
There's a few problems with the way the accelerometer monitor is currently implemented:
Looking at the sensor changed code here:
```
float speed = Math.abs(
                            accel_values[0] + accel_values[1] + accel_values[2] -
                                    last_accel_values[0] + last_accel_values[1] + last_accel_values[2])
                            / diffTime * 1000;
```
It looks like you're trying to differentiate the change in acceleration over time, however, simply summing the x,y and z values from accel_values and last_accel_values is incorrect (plus the typo of only negating last_accel_values[0], but not [1] or [2]). You would normally either compare them separately (dAx=Math.abs(accel_values[0]-last_accel_values[0] etc), or compare the vectors of accel_values and last_accel_values:
````
double dA = Math.abs(
                            Math.sqrt(accel_values[0]*accel_values[0] +accel_values[1]*accel_values[1]+accel_values[2]*accel_values[2] )
                            -Math.sqrt(last_accel_values[0]*last_accel_values[0] +last_accel_values[1]*last_accel_values[1]+last_accel_values[2]*last_accel_values[2] )
                    );
                    double jerk = dA/(diffTime*1000);
````
The change in acceleration over time is _jerk_ ( https://en.wikipedia.org/wiki/Jerk_(physics) ). Is this what you want?

You've named the variable `speed`, but speed is simply acceleration*time.

Few other things to note:
When device is flat on the table, the acceleration vector from the sensor is 9.8 toward the ground (ie, the force of gravity).
When device is in freefall, the acceleration vector from the sensor is 0.

This part doesn't make much sense at all, I'm not sure it's supposed to be here (in AccelConfigureActivity):
````
  double averageDB = 0.0;
                        if (speed != 0) {
                            averageDB = 20 * Math.log10(Math.abs(speed) / 1);
                        }

                        if (averageDB > maxAmp) {
                            maxAmp = averageDB + 5d; //add 5db buffer
                            mNumberTrigger.setValue(new Integer((int)maxAmp));
                            mNumberTrigger.invalidate();
                        }
````
Looks like it's changing the threshold value based on the current value. I'd suggest using 9.8 as the threshold instead (Android helpfully defines it here https://developer.android.com/reference/android/hardware/SensorManager.html#GRAVITY_EARTH )


**New in this PR**
Android provides a _significant motion sensor_, which is triggered when the device is moved. I have added a `BumpMonitor` which uses this sensor. It might be interesting to experiment with this one, compared with the Accelerometer. It does seem to be a lot less sensitive.
