### PR TITLE
Add switch to toggle lock screen notification

### DIFF
--- a/src/main/java/org/havenapp/main/PreferenceManager.java
+++ b/src/main/java/org/havenapp/main/PreferenceManager.java
@@ -67,6 +67,8 @@ public class PreferenceManager {
 
     private static final String FIRST_LAUNCH = "first_launch";
 
+    private static final String SHOW_NOTIFICATION = "show_notification";
+
 
     private Context context;
 	
@@ -302,5 +304,14 @@ public class PreferenceManager {
     public int getAudioLength ()
     {
         return 15000; //30 seconds
+    }
+
+    public void setShowNotification(boolean showNotification) {
+      prefsEditor.putBoolean(SHOW_NOTIFICATION, showNotification);
+      prefsEditor.commit();
+    }
+
+    public boolean getShowNotification() {
+      return appSharedPrefs.getBoolean(SHOW_NOTIFICATION, true);
     }
 }

--- a/src/main/java/org/havenapp/main/SettingsActivity.java
+++ b/src/main/java/org/havenapp/main/SettingsActivity.java
@@ -31,6 +31,7 @@ import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.SwitchCompat;
 import android.support.v7.widget.Toolbar;
 import android.text.InputType;
 import android.text.TextUtils;
@@ -82,6 +83,16 @@ public class SettingsActivity extends AppCompatActivity {
          */
         File directory = new File(Environment.getExternalStorageDirectory() + preferences.getDirPath());
         directory.mkdirs();
+
+        final SwitchCompat showNotifications = (SwitchCompat) this.findViewById(R.id.show_notification);
+
+        showNotifications.setChecked(preferences.getShowNotification());
+
+        showNotifications.setOnCheckedChangeListener(new OnCheckedChangeListener() {
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                preferences.setShowNotification(isChecked);
+            }
+        });
 
         /**
          * Checkboxes for enabled app options
@@ -249,6 +260,9 @@ public class SettingsActivity extends AppCompatActivity {
 
     private void save ()
     {
+        SwitchCompat showNotifications = (SwitchCompat) findViewById(R.id.show_notification);
+
+        preferences.setShowNotification(showNotifications.isChecked());
 
         EditText phoneNumber = (EditText)
                 this.findViewById(R.id.phone_number);

--- a/src/main/java/org/havenapp/main/service/MonitorService.java
+++ b/src/main/java/org/havenapp/main/service/MonitorService.java
@@ -140,7 +140,9 @@ public class MonitorService extends Service {
 
         startSensors();
 
-        showNotification();
+        if(mPrefs.getShowNotification()) {
+          showNotification();
+        }
 
         PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
         wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK,

--- a/src/main/res/layout/activity_settings.xml
+++ b/src/main/res/layout/activity_settings.xml
@@ -22,6 +22,22 @@
 	android:padding="6sp"
 	>
 
+  <LinearLayout
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+    <TextView
+      android:id="@+id/show_notification_prompt"
+      android:text="@string/show_notification_prompt"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_weight="1" />
+    <android.support.v7.widget.SwitchCompat
+      android:id="@+id/show_notification"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content" />
+  </LinearLayout>
+
 	<TextView
 		android:id="@+id/camera_prompt"
 		android:text="@string/camera_prompt"

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -10,6 +10,10 @@
 
     <string name="title_activity_start">Haven</string>
 
+    <string name="show_notification_prompt">
+      Show notification on lock screen
+    </string>
+
     <string name="accelerometer_prompt">
     	Movement Sensitivity
     </string>


### PR DESCRIPTION
A switch allows users to specify whether or not Haven displays a
notification on the lock screen when active.

Closes: #44