### PR TITLE
Mistake in function call (setPreviewFpsRange)

### DIFF
--- a/src/main/java/org/havenapp/main/sensors/motion/Preview.java
+++ b/src/main/java/org/havenapp/main/sensors/motion/Preview.java
@@ -192,7 +192,7 @@ public class Preview extends SurfaceView implements SurfaceHolder.Callback {
 
 			List<int[]> fpsRange = parameters.getSupportedPreviewFpsRange();
             try {
-                parameters.setPreviewFpsRange(fpsRange.get(fpsRange.size() - 1)[1], fpsRange.get(fpsRange.size() - 1)[1]);
+                parameters.setPreviewFpsRange(fpsRange.get(fpsRange.size() - 1)[0], fpsRange.get(fpsRange.size() - 1)[1]);
             }
             catch (Exception e) {
                 Log.w("Camera","Error setting frames per second",e);


### PR DESCRIPTION
The application ends with an error when the activity **Preview** starts:
```
E/AndroidRuntime: FATAL EXCEPTION: main
                  Process: org.havenapp.main, PID: 19071
                  java.lang.RuntimeException: setParameters failed
                      at android.hardware.Camera.native_setParameters(Native Method)
                      at android.hardware.Camera.setParameters(Camera.java:1972)
                      at org.havenapp.main.sensors.motion.Preview.surfaceCreated(Preview.java:214)
                      at android.view.SurfaceView.updateWindow(SurfaceView.java:580)
                      at android.view.SurfaceView$3.onPreDraw(SurfaceView.java:176)
                      at android.view.ViewTreeObserver.dispatchOnPreDraw(ViewTreeObserver.java:944)
                      at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:1970)
                      at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1061)
                      at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:5891)
                      at android.view.Choreographer$CallbackRecord.run(Choreographer.java:767)
                      at android.view.Choreographer.doCallbacks(Choreographer.java:580)
                      at android.view.Choreographer.doFrame(Choreographer.java:550)
                      at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:753)
                      at android.os.Handler.handleCallback(Handler.java:739)
                      at android.os.Handler.dispatchMessage(Handler.java:95)
                      at android.os.Looper.loop(Looper.java:135)
                      at android.app.ActivityThread.main(ActivityThread.java:5294)
                      at java.lang.reflect.Method.invoke(Native Method)
                      at java.lang.reflect.Method.invoke(Method.java:372)
                      at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:904)
                      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:699)
```
(Tested on 'Sony Z1 compact' phone)

Error in the first argument when the function **setPreviewFpsRange()** is called. Here passing maximum value from last pair getted from **getSupportedPreviewFpsRange()** for the both arguments, while according the [docs](https://developer.android.com/reference/android/hardware/Camera.Parameters.html#setPreviewFpsRange(int,%20int)):
> The minimum and maximum preview fps must be one of the elements from getSupportedPreviewFpsRange().

Possibly this will fix the following issues: #105 #122 #124 