### PR TITLE
Make it clear that Signal app is not a prerequisite for Signal notifications to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ When one of the sensors is triggered (reaches the configured sensitivity thresho
 - SMS: a message is sent to the number specified when monitoring started
 - Signal: if configured, can send end-to-end encryption notifications via Signal
 
+Note that it's not necessary to install the Signal app on the device that runs Haven. Doing so may invalidate the app's previous Signal registration and safety numbers. Haven uses APIs to communicate via Signal.
+
 Notifications are sent through a service running in the background that is defined in class `MonitorService`.
 
 ### Remote Access


### PR DESCRIPTION
Given that Orbot is a dependency for Onion Services, I mistakenly assumed that the official Signal app was also a dependency for Signal notifications to work.

This led to some confusion when, after configuring Signal within Haven, it deregistered my previous 'official' app registration and subsequently unverified the safety number on my receiving phone.

This is just a README change to clarify that Signal app is not necessary for the functionality to work.