### PR TITLE
Set the "best" valid preview size and fpsrange cameraPreferences.

### DIFF
--- a/src/main/java/org/havenapp/main/sensors/motion/Preview.java
+++ b/src/main/java/org/havenapp/main/sensors/motion/Preview.java
@@ -183,17 +183,36 @@ public class Preview extends SurfaceView implements SurfaceHolder.Callback {
 			final Camera.Parameters parameters = camera.getParameters();
 
 			try {
-                List<Size> sizesPreviews = parameters.getSupportedPreviewSizes();
-                parameters.setPreviewSize(sizesPreviews.get(4).width, sizesPreviews.get(4).height);
-            }
-            catch (Exception e){
-			    Log.w("Camera","Error setting camera preview size",e);
-            }
+				List<Size> sizesPreviews = parameters.getSupportedPreviewSizes();
 
-			List<int[]> fpsRange = parameters.getSupportedPreviewFpsRange();
-            try {
-                parameters.setPreviewFpsRange(fpsRange.get(fpsRange.size() - 1)[1], fpsRange.get(fpsRange.size() - 1)[1]);
-            }
+				Size bestSize = sizesPreviews.get(0);
+
+				for (int i = 1; i < sizesPreviews.size(); i++) {
+					if ((sizesPreviews.get(i).width * sizesPreviews.get(i).height) >
+							(bestSize.width * bestSize.height)) {
+						bestSize = sizesPreviews.get(i);
+					}
+				}
+
+				parameters.setPreviewSize(bestSize.width, bestSize.height);
+
+			} catch (Exception e) {
+				Log.w("Camera", "Error setting camera preview size", e);
+			}
+
+			try {
+				List<int[]> ranges = parameters.getSupportedPreviewFpsRange();
+				int[] bestRange = ranges.get(0);
+				for (int i = 1; i < ranges.size(); i++) {
+					if (ranges.get(i)[1] >
+							bestRange[1]) {
+						bestRange[0] = ranges.get(i)[0];
+						bestRange[1] = ranges.get(i)[1];
+
+					}
+				}
+				parameters.setPreviewFpsRange(bestRange[0], bestRange[1]);
+			}
             catch (Exception e) {
                 Log.w("Camera","Error setting frames per second",e);
             }


### PR DESCRIPTION
Fixes two bugs I'm seeing on my Nexus 4:

`AndroidRuntime: java.lang.RuntimeException: setParameters failed
AndroidRuntime: 	at android.hardware.Camera.native_setParameters(Native Method)
AndroidRuntime: 	at android.hardware.Camera.setParameters(Camera.java:2015)`

This bug occurs related to the use of a hardcoded preview size (always
choosing the 4th preview size) and fpsrange (always choosing the last),
which actually contains a bug, resulting in:

`E QCameraHWI_Parm: status_t android::QCameraHardwareInterface::setPreviewFpsRange(const android::QCameraParameters &): error: FPS range value not supported`

Thanks to this [question](https://stackoverflow.com/questions/38279166/how-to-resolve-the-android-camera-setparameters-failed
) by Raj here on stackoverflow.

I found the question itself had the more useful info than the answer in that it shows how to interate through the reported sizes/ranges to find the "best one", which is just the one with the biggest area (W x H).  If this is not desired, it could be substituted with another method.

Update:  Looks like a similar solution is also [here](https://stackoverflow.com/questions/5802681/android-error-in-camera-surface) by Scottie.

Anyway-- I also search through the various previewfpsranges looking for
the "best" one, which I'm assuming is the one with the highest max fps.

I'm actually not 100% sure what the desired effect is is in choosing these preview sizes, so if area + max
frame rate aren't desired or the highest frame rate isn't wanted, this might not be the best way to go.  But at least it is choosing values from the list that are actually there :)

Tested on the nexus 4 (android 7.1.2) and a Shield Tablet (Android 6.0.1).  Pleae test on other devices.

----

Also, this is a different solution to the one in PR #139, which I hadn't seen when I created this initially.