### PR TITLE
#71 bind WebServer to 127.0.0.1

### DIFF
--- a/src/main/java/org/havenapp/main/service/WebServer.java
+++ b/src/main/java/org/havenapp/main/service/WebServer.java
@@ -23,6 +23,7 @@ import org.havenapp.main.model.EventTrigger;
 
 public class WebServer extends NanoHTTPD {
 
+    public final static String LOCAL_HOST = "127.0.0.1";
     public final static int LOCAL_PORT = 8888;
 
     private final static String TAG = "WebServer";
@@ -34,7 +35,7 @@ public class WebServer extends NanoHTTPD {
     private Context mContext;
 
     public WebServer(Context context) throws IOException {
-        super(LOCAL_PORT);
+        super(LOCAL_HOST, LOCAL_PORT);
         mContext = context;
         start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
     }


### PR DESCRIPTION
Fixes #71 

Tested from a signed & installed APK on a Samsung Galaxy J1 Mini (Android 5.1.1) built from source. 

I verified with the 'NetStat Plus' app that the Haven WebServer was now bound to 127.0.0.1 and that the Onion Service was still reachable.

Since the Onion Service request is only against the port, this should not cause problems for existing installs.