### PR TITLE
Change the derlio audio-waveform dependency to one that seems to work

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ dependencies {
     compile 'me.angrybyte.picker:picker:1.3.1'
     compile 'com.github.stfalcon:frescoimageviewer:0.5.0'
     compile 'com.facebook.fresco:fresco:1.7.1'
-    compile 'com.github.derlio.waveform:library:1.0.3@aar'
+    compile 'com.github.derlio:audio-waveform:v1.0.1'
     compile 'org.firezenk:audiowaves:1.1@aar'
     compile 'com.maxproj.simplewaveform:app:1.0.0'
 


### PR DESCRIPTION
As mentioned in #142, when attempting to build the project in Android Studio, Gradle was failing because it could not download https://jitpack.io/com/github/derlio/waveform/library/1.0.3/library-1.0.3.pom (as you can see for yourself, it throws a 401 Authorization response). This prevented me from building the app.

The compile dependency was exactly as per the README.md at https://github.com/derlio/audio-waveform:

```
compile 'com.github.com.derlio.waveform:library:1.0.3@aar'
```

I went to https://jitpack.io and entered 'derlio/waveform' in the search bar, which took me to https://jitpack.io/#derlio/audio-waveform/v1.0.1

Those instructions say to use instead the following:

```
compile 'com.github.derlio:audio-waveform:v1.0.1'
```

This works for me.

I'm not exactly sure what's going on here since there are many projects on Github that use the former just as you have. And surely it must've been working up until recently or else no-one could build at all. Maybe the developer changed something in Jitpack and the 1.0.3 release disappeared as a result.

Feel free to close if I'm simply Doing It Wrong or there's another way to get the 1.0.3 release..