### PR TITLE
add largeHeap true for Prevent OutOfMemoryError OOM

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         android:label="@string/app_name"
         tools:replace="android:allowBackup"
         android:allowBackup="false"
+        android:largeHeap="true"
         android:theme="@style/AppTheme">
         <activity
             android:name="org.havenapp.main.ListActivity"


### PR DESCRIPTION
OutOfMemoryError OOM createBitmap MotionAsyncTask.java:118

Samsung Galaxy S5 (Japan au/KDDI SCL23, OS 4.4.2)
When detect camera motion has changed . Occur OutOfMemoryError OOM .
So I add largeHeap="true" to AndroidManifest.xml .

Error Log
 E/art(17333): Throwing OutOfMemoryError "Failed to allocate a 8294412 byte allocation with 7418352 free bytes"
 E/AndroidRuntime(17333): FATAL EXCEPTION: Thread-1638
 E/AndroidRuntime(17333): Process: org.havenapp.main, PID: 17333
 E/AndroidRuntime(17333): java.lang.OutOfMemoryError: Failed to allocate a 8294412 byte allocation with 7418352 free bytes
 E/AndroidRuntime(17333):  at android.graphics.Bitmap.nativeCreate(Native Method)
 E/AndroidRuntime(17333):  at android.graphics.Bitmap.createBitmap(Bitmap.java:924)
 E/AndroidRuntime(17333):  at android.graphics.Bitmap.createBitmap(Bitmap.java:901)
 E/AndroidRuntime(17333):  at android.graphics.Bitmap.createBitmap(Bitmap.java:833)
 E/AndroidRuntime(17333):  at org.havenapp.main.sensors.media.MotionAsyncTask.run(MotionAsyncTask.java:118)
