### PR TITLE
Change the <title> of the webserver interface to Haven

### DIFF
--- a/src/main/java/org/havenapp/main/service/WebServer.java
+++ b/src/main/java/org/havenapp/main/service/WebServer.java
@@ -143,7 +143,7 @@ public class WebServer extends NanoHTTPD {
 
     private void showLogin (StringBuffer page) {
 
-        page.append("<html><head><title>PhoneyPot</title>");
+        page.append("<html><head><title>Haven</title>");
         page.append("<meta http-equiv=\"Content-Type\" content=\"application/xhtml+xml; charset=utf-8\" />");
         page.append("<meta name = \"viewport\" content = \"user-scalable=no, initial-scale=1.0, maximum-scale=1.0, width=device-width\">");
         page.append("</head><body>");

--- a/src/main/java/org/havenapp/main/service/WebServer.java
+++ b/src/main/java/org/havenapp/main/service/WebServer.java
@@ -143,7 +143,7 @@ public class WebServer extends NanoHTTPD {
 
     private void showLogin (StringBuffer page) {
 
-        page.append("<html><head><title>Haven</title>");
+        page.append("<html><head><title>").append(appTitle).append("</title>");
         page.append("<meta http-equiv=\"Content-Type\" content=\"application/xhtml+xml; charset=utf-8\" />");
         page.append("<meta name = \"viewport\" content = \"user-scalable=no, initial-scale=1.0, maximum-scale=1.0, width=device-width\">");
         page.append("</head><body>");


### PR DESCRIPTION
The <title> of the webserver's page being 'PhoneyPot' might alarm users who weren't familiar with the early incarnation of the project (might even worry it's a MITM). Updated to 'Haven'