### PR TITLE
Fixes the abbreviation of FPF

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Learn more about the story of this project at the links below:
 
 ## Project Team
 
-Haven was developed through a collaboration between [Freedom of the Press Foundation](https://freedom.press) and [Guardian Project](https://guardianproject.info). Prototype funding was generously provided by FoPF, and donations to support continuing work can be contributed through their site: https://freedom.press/donate-support-haven-open-source-project/
+Haven was developed through a collaboration between [Freedom of the Press Foundation](https://freedom.press) and [Guardian Project](https://guardianproject.info). Prototype funding was generously provided by FPF, and donations to support continuing work can be contributed through their site: https://freedom.press/donate-support-haven-open-source-project/
 
 ![Freedom of the Press Foundation](https://raw.githubusercontent.com/guardianproject/haven/master/art/logos/fopflogo.png)
 ![Guardian Project](https://raw.githubusercontent.com/guardianproject/haven/master/art/logos/gplogo.png)

--- a/fastlane/android/metadata/en-US/full_description.txt
+++ b/fastlane/android/metadata/en-US/full_description.txt
@@ -15,7 +15,7 @@ Project Team
 
 Haven was developed through a collaboration between Freedom of the
 Press Foundation and Guardian Project. Prototype funding was
-generously provided by FoPF, and donations to support continuing work
+generously provided by FPF, and donations to support continuing work
 can be contributed through their site:
 https://freedom.press/donate-support-haven-open-source-project
 


### PR DESCRIPTION
Freedom of the Press Foundation uses the abbreviation *FPF*, in the description it was mentioned as *FoPF* before. This patch fixes that.