### PR TITLE
Use 'Save Number' dialog for Remote Signal number rather than Register

### DIFF
--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -44,6 +44,11 @@
         <item name="negativeButtonText">@android:string/cancel</item>
     </style>
 
+    <style name="AppPreference.DialogPreferenceSave">
+        <item name="positiveButtonText">@string/save_number</item>
+        <item name="negativeButtonText">@android:string/cancel</item>
+    </style>
+
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />

--- a/src/main/res/xml/settings.xml
+++ b/src/main/res/xml/settings.xml
@@ -31,7 +31,7 @@
             android:title="@string/sms_label" />
 
         <EditTextPreference
-            style="@style/AppPreference.DialogPreferenceRegister"
+            style="@style/AppPreference.DialogPreferenceSave"
             android:dialogLayout="@layout/pref_dialog_edit_text_hint"
             android:dialogMessage="@string/sms_dialog_message"
             android:inputType="phone"


### PR DESCRIPTION
Fixes #192 (I think)

Because of my comment in https://github.com/guardianproject/haven/issues/184#issuecomment-354880620, I can't build the app in Android Studio, in order to test the change properly.. please close if it's not right.