### PR TITLE
Don't show password on screen

### DIFF
--- a/src/main/java/org/havenapp/main/SettingsFragment.java
+++ b/src/main/java/org/havenapp/main/SettingsFragment.java
@@ -104,7 +104,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
 
         if (checkValidString(preferences.getRemoteAccessCredential())) {
             ((EditTextPreference) findPreference(PreferenceManager.REMOTE_ACCESS_CRED)).setText(preferences.getRemoteAccessCredential().trim());
-            findPreference(PreferenceManager.REMOTE_ACCESS_CRED).setSummary(preferences.getRemoteAccessCredential().trim());
+            findPreference(PreferenceManager.REMOTE_ACCESS_CRED).setSummary(R.string.bullets);
         } else {
             findPreference(PreferenceManager.REMOTE_ACCESS_CRED).setSummary(R.string.remote_access_credential_hint);
         }
@@ -293,7 +293,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
             String text = ((EditTextPreference) findPreference(PreferenceManager.REMOTE_ACCESS_CRED)).getText();
             if (checkValidString(text)) {
                 preferences.setRemoteAccessCredential(text.trim());
-                findPreference(PreferenceManager.REMOTE_ACCESS_CRED).setSummary(preferences.getRemoteAccessCredential().trim());
+                findPreference(PreferenceManager.REMOTE_ACCESS_CRED).setSummary(R.string.bullets);
             } else {
                 preferences.setRemoteAccessCredential(text);
                 findPreference(PreferenceManager.REMOTE_ACCESS_CRED).setSummary(R.string.remote_access_credential_hint);

--- a/src/main/res/layout/pref_dialog_edit_password.xml
+++ b/src/main/res/layout/pref_dialog_edit_password.xml
@@ -1,0 +1,36 @@
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_marginBottom="@dimen/activity_vertical_large_margin"
+    android:layout_marginTop="@dimen/activity_vertical_large_margin"
+    android:overScrollMode="ifContentScrolls">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="@dimen/alert_def_padding"
+        android:paddingBottom="@dimen/alert_def_padding"
+        android:paddingEnd="?dialogPreferredPadding"
+        android:paddingLeft="?dialogPreferredPadding"
+        android:paddingRight="?dialogPreferredPadding"
+        android:paddingStart="?dialogPreferredPadding"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@android:id/message"
+            style="?android:attr/textAppearanceSmall"
+            android:layout_marginBottom="@dimen/alert_def_padding"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="?android:attr/textColorSecondary" />
+
+        <EditText
+            android:inputType="textPassword"
+            android:id="@android:id/edit"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/password"/>
+
+    </LinearLayout>
+</ScrollView>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <string name="app_name" translatable="false">Haven</string>
-
+    <string name="bullets" translatable="false">•••••••</string>
     <string name="menu_save">Save</string>
     <string name="menu_about">Setup...</string>
 

--- a/src/main/res/xml/settings.xml
+++ b/src/main/res/xml/settings.xml
@@ -73,7 +73,7 @@
             android:title="@string/service_address" />
 
         <EditTextPreference
-            android:dialogLayout="@layout/pref_dialog_edit_text"
+            android:dialogLayout="@layout/pref_dialog_edit_password"
             android:dialogMessage="@string/remote_access_credential_hint"
             android:inputType="textPassword"
             android:key="remote_access_credential"


### PR DESCRIPTION
The [EditTextPreference's inputType="textPassword"](https://github.com/guardianproject/haven/blob/master/src/main/res/xml/settings.xml#L75-L82) in `settings.xml` is currently ignored because its [dialog layout](https://github.com/guardianproject/haven/blob/master/src/main/res/layout/pref_dialog_edit_text.xml) uses [a regular "text" inputType](https://github.com/guardianproject/haven/blob/master/src/main/res/layout/pref_dialog_edit_text.xml#L28).  So I fixed it.

This could be handled several ways for size, but I just kept it matching the current way the settings are done, including a separate file for the dialog layout.

Note:  those ?dialogPreferredPaddings are coming up red in AS and probably shouldn't be used like that, but I guess it doesn't break anything.  I just used the same file basically as [src/main/res/layout/pref_dialog_edit_text.xml](https://github.com/guardianproject/haven/blob/master/src/main/res/layout/pref_dialog_edit_text.xml#L28) only for a password field.

Also changed it so that the password isn't displayed on the setting, but rather a fixed-# of bullets.

Question, and I'll probably make this an official issue, but should the password and/or other fields be available to Oreo's Autofill service?  If not, we might want to explicitly deny it, but I didn't do it in this commit.

