### PR TITLE
Fix: #233 allow screen lock after timer

### DIFF
--- a/src/main/java/org/havenapp/main/MonitorActivity.java
+++ b/src/main/java/org/havenapp/main/MonitorActivity.java
@@ -257,6 +257,7 @@ public class MonitorActivity extends AppCompatActivity implements TimePickerDial
 
             public void onFinish() {
 
+                getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
                 txtTimer.setText(R.string.status_on);
                 initMonitor();
                 mOnTimerTicking = false;


### PR DESCRIPTION
Remove flag here, it is set again. Please review:
- [x] Tested on device & simulator
- [x] Built against latest version