### PR TITLE
Bugfix #233 allow screen to lock after countdown

### DIFF
--- a/src/main/java/org/havenapp/main/MonitorActivity.java
+++ b/src/main/java/org/havenapp/main/MonitorActivity.java
@@ -257,6 +257,7 @@ public class MonitorActivity extends AppCompatActivity implements TimePickerDial
 
             public void onFinish() {
 
+                getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
                 txtTimer.setText(R.string.status_on);
                 initMonitor();
                 mOnTimerTicking = false;


### PR DESCRIPTION
Resolve #233 
Remove flags here to allow sleep, no noted negative impact. If Preview being destroyed is the root cause then feel free to close this; thanks again for the update.
- [x] Tested on device & simulator
- [x] Built against latest version
