### PR TITLE
More build/library updates for Android Studio 3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0-alpha09'
 
     }
 
@@ -101,28 +101,28 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:27.0.2'
-    compile 'com.android.support:appcompat-v7:27.0.2'
-    compile 'com.android.support:design:27.0.2'
-    compile 'com.android.support:cardview-v7:27.0.2'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
-    compile 'com.github.guardianproject:signal-cli-android:-SNAPSHOT'
-    compile 'com.github.satyan:sugar:1.5'
-    compile 'com.squareup.picasso:picasso:2.5.2'
-    compile 'net.the4thdimension:audio-wife:1.0.3'
-    compile 'com.github.apl-devs:appintro:v4.2.2'
-    compile 'info.guardianproject.netcipher:netcipher:2.0.0-alpha1'
-    compile 'com.nanohttpd:nanohttpd-webserver:2.2.0'
-    compile 'me.angrybyte.picker:picker:1.3.1'
-    compile 'com.github.stfalcon:frescoimageviewer:0.5.0'
-    compile 'com.facebook.fresco:fresco:1.7.1'
-    compile 'com.github.derlio.waveform:library:1.0.3@aar'
-    compile 'org.firezenk:audiowaves:1.1@aar'
-    compile 'com.maxproj.simplewaveform:app:1.0.0'
-    compile 'com.takisoft.fix:preference-v7:27.0.2.0'
-    compile 'com.wdullaer:materialdatetimepicker:3.5.0'
+    implementation 'com.android.support:support-v4:27.0.2'
+    implementation 'com.android.support:appcompat-v7:27.0.2'
+    implementation 'com.android.support:design:27.0.2'
+    implementation 'com.android.support:cardview-v7:27.0.2'
+    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'com.github.guardianproject:signal-cli-android:-SNAPSHOT'
+    implementation 'com.github.satyan:sugar:1.5'
+    implementation 'com.squareup.picasso:picasso:2.5.2'
+    implementation 'net.the4thdimension:audio-wife:1.0.3'
+    implementation 'com.github.apl-devs:appintro:v4.2.2'
+    implementation 'info.guardianproject.netcipher:netcipher:2.0.0-alpha1'
+    implementation 'com.nanohttpd:nanohttpd-webserver:2.2.0'
+    implementation 'me.angrybyte.picker:picker:1.3.1'
+    implementation 'com.github.stfalcon:frescoimageviewer:0.5.0'
+    implementation 'com.facebook.fresco:fresco:1.8.0'
+    implementation 'com.github.derlio.waveform:library:1.0.3@aar'
+    implementation 'org.firezenk:audiowaves:1.1@aar'
+    implementation 'com.maxproj.simplewaveform:app:1.0.0'
+    implementation 'com.takisoft.fix:preference-v7:27.0.2.0'
+    implementation 'com.wdullaer:materialdatetimepicker:3.5.0'
 
-    implementation('com.mikepenz:aboutlibraries:6.0.1@aar') {
+    implementation('com.mikepenz:aboutlibraries:6.0.2@aar') {
         transitive = true
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip
+android.enableD8=true


### PR DESCRIPTION
* Update Gradle to 4.5 from 4.4.1
* enable new dex compiler
* use newer "implementation" syntax
* update a few libraries to latest

Note this uses the experimental gradle plugin (3.1.0-alpha9) &
experimental D8 compiler, but I haven't noticed any issues and builds
should be faster & apk binaries should be smaller.

That said, please test!