### PR TITLE
Fix leaked service connection in #248

### DIFF
--- a/src/main/java/org/havenapp/main/sensors/motion/Preview.java
+++ b/src/main/java/org/havenapp/main/sensors/motion/Preview.java
@@ -124,8 +124,9 @@ public class Preview extends SurfaceView implements SurfaceHolder.Callback {
 	/*
 		 * We bind to the alert service
 		 */
-        context.bindService(new Intent(context,
-                MonitorService.class), mConnection, Context.BIND_ABOVE_CLIENT);}
+        this.context.bindService(new Intent(context,
+                MonitorService.class), mConnection, Context.BIND_ABOVE_CLIENT);
+	}
 
 				public void setMotionSensitivity (int
 				motionSensitivity )
@@ -393,8 +394,7 @@ public class Preview extends SurfaceView implements SurfaceHolder.Callback {
             // Surface will be destroyed when we return, so stop the preview.
             // Because the CameraDevice object is not a shared resource, it's very
             // important to release it when the activity is paused.
-            if (serviceMessenger != null)
-                context.unbindService(mConnection);
+            this.context.unbindService(mConnection);
 
             camera.setPreviewCallback(null);
             camera.stopPreview();

--- a/src/main/java/org/havenapp/main/ui/CameraConfigureActivity.java
+++ b/src/main/java/org/havenapp/main/ui/CameraConfigureActivity.java
@@ -126,6 +126,7 @@ public class CameraConfigureActivity extends AppCompatActivity {
     @Override
     public void onResume() {
         super.onResume();
+        mFragment.stopCamera();
     }
 
     @Override


### PR DESCRIPTION
**Review appreciated**

This is a fix but not the root cause; seems the connection uses context from before the image is processed then Preview does work on a lost activity. 

- Solves bind handler errors introduced with `CameraConfigureActivity` as the `unbindService` call would never fire as configured.
- Possible fix for #258, #266 and others.
