### PR TITLE
Fix: hide keys on notification slide entry completion 

### DIFF
--- a/src/main/res/layout/custom_slide_notify.xml
+++ b/src/main/res/layout/custom_slide_notify.xml
@@ -27,6 +27,7 @@
         android:hint="@string/sms_hint"
         android:gravity="center"
         android:inputType="phone"
+        android:imeOptions="actionDone"
         android:id="@+id/editNumber"
         />
 


### PR DESCRIPTION
- The button was not closing the soft keyboard in the PPAppIntro

Tested using Android 5.1 on device + simulator
