### PR TITLE
Add heartbeat notifications

### DIFF
--- a/src/main/java/org/havenapp/main/HavenApp.java
+++ b/src/main/java/org/havenapp/main/HavenApp.java
@@ -27,6 +27,7 @@ import com.orm.SugarContext;
 
 import java.io.IOException;
 
+import org.havenapp.main.service.SignalSender;
 import org.havenapp.main.service.WebServer;
 
 public class HavenApp extends MultiDexApplication {
@@ -52,6 +53,10 @@ public class HavenApp extends MultiDexApplication {
         if (mPrefs.getRemoteAccessActive())
             startServer();
 
+        if (mPrefs.getHeartbeatActive()) {
+            SignalSender sender = SignalSender.getInstance(this, mPrefs.getSignalUsername());
+            sender.startHeartbeatTimer(mPrefs.getHeartbeatNotificationTimeMs());
+        }
     }
 
 

--- a/src/main/java/org/havenapp/main/PreferenceManager.java
+++ b/src/main/java/org/havenapp/main/PreferenceManager.java
@@ -28,10 +28,10 @@ import org.havenapp.main.sensors.motion.LuminanceMotionDetector;
 
 
 public class PreferenceManager {
-	
+
     private SharedPreferences appSharedPrefs;
     private Editor prefsEditor;
-    
+
     public static final String LOW = "Low";
     public static final String MEDIUM = "Medium";
     public static final String HIGH = "High";
@@ -41,7 +41,7 @@ public class PreferenceManager {
     public static final String FRONT = "Front";
     public static final String BACK = "Back";
     public static final String NONE = "None";
-	
+
     private static final String APP_SHARED_PREFS="org.havenapp.main";
     private static final String ACCELEROMETER_ACTIVE="accelerometer_active";
     private static final String ACCELEROMETER_SENSITIVITY="accelerometer_sensibility";
@@ -50,6 +50,8 @@ public class PreferenceManager {
     public static final String CAMERA_SENSITIVITY="camera_sensitivity";
     public static final String CONFIG_MOVEMENT ="config_movement";
     private static final String FLASH_ACTIVE="flash_active";
+    public static final String  HEARTBEAT_MONITOR_ACTIVE="heartbeat_monitor_active";
+    public static final String  HEARTBEAT_MONITOR_DELAY="heartbeat_monitor_delay";
     private static final String MICROPHONE_ACTIVE="microphone_active";
     private static final String MICROPHONE_SENSITIVITY="microphone_sensitivity";
     public static final String CONFIG_SOUND = "config_sound";
@@ -60,10 +62,10 @@ public class PreferenceManager {
     public static final String VERIFY_SIGNAL = "verify_signal";
     public static final String SEND_SMS = "send_sms";
     private static final String UNLOCK_CODE="unlock_code";
-	
+
     private static final String ACCESS_TOKEN="access_token";
     private static final String DELEGATED_ACCESS_TOKEN="deferred_access_token";
-	
+
     private static final String PHONE_ID="phone_id";
     private static final String TIMER_DELAY="timer_delay";
     private static final String VIDEO_LENGTH="video_length";
@@ -83,7 +85,7 @@ public class PreferenceManager {
     public static final String DISABLE_BATTERY_OPT = "config_battery_optimizations";
 
     private Context context;
-	
+
     public PreferenceManager(Context context) {
         this.context = context;
         this.appSharedPrefs = context.getSharedPreferences(APP_SHARED_PREFS, Activity.MODE_PRIVATE);
@@ -139,21 +141,21 @@ public class PreferenceManager {
     }
 
     public void activateAccelerometer(boolean active) {
-    	prefsEditor.putBoolean(ACCELEROMETER_ACTIVE, active);
-    	prefsEditor.commit();
+        prefsEditor.putBoolean(ACCELEROMETER_ACTIVE, active);
+        prefsEditor.commit();
     }
-    
+
     public boolean getAccelerometerActivation() {
-    	return appSharedPrefs.getBoolean(ACCELEROMETER_ACTIVE, true);
+        return appSharedPrefs.getBoolean(ACCELEROMETER_ACTIVE, true);
     }
-    
+
     public void setAccelerometerSensitivity(String sensitivity) {
-    	prefsEditor.putString(ACCELEROMETER_SENSITIVITY, sensitivity);
-    	prefsEditor.commit();
+        prefsEditor.putString(ACCELEROMETER_SENSITIVITY, sensitivity);
+        prefsEditor.commit();
     }
-    
+
     public String getAccelerometerSensitivity() {
-    	return appSharedPrefs.getString(ACCELEROMETER_SENSITIVITY, HIGH);
+        return appSharedPrefs.getString(ACCELEROMETER_SENSITIVITY, HIGH);
     }
 
     public void setActivateVideoMonitoring(boolean active) {
@@ -166,76 +168,94 @@ public class PreferenceManager {
     }
 
     public void activateCamera(boolean active) {
-    	prefsEditor.putBoolean(CAMERA_ACTIVE, active);
-    	prefsEditor.commit();
+        prefsEditor.putBoolean(CAMERA_ACTIVE, active);
+        prefsEditor.commit();
     }
-    
+
     public boolean getCameraActivation() {
-    	return appSharedPrefs.getBoolean(CAMERA_ACTIVE, true);
+        return appSharedPrefs.getBoolean(CAMERA_ACTIVE, true);
     }
-    
+
     public void setCamera(String camera) {
-    	prefsEditor.putString(CAMERA, camera);
-    	prefsEditor.commit();
+        prefsEditor.putString(CAMERA, camera);
+        prefsEditor.commit();
     }
-    
+
     public String getCamera() {
-    	return appSharedPrefs.getString(CAMERA, FRONT);
+        return appSharedPrefs.getString(CAMERA, FRONT);
     }
-    
+
     public void setCameraSensitivity(int sensitivity) {
-    	prefsEditor.putInt(CAMERA_SENSITIVITY, sensitivity);
-    	prefsEditor.commit();
+        prefsEditor.putInt(CAMERA_SENSITIVITY, sensitivity);
+        prefsEditor.commit();
     }
-    
+
     public int getCameraSensitivity() {
-    	return appSharedPrefs.getInt(CAMERA_SENSITIVITY, LuminanceMotionDetector.MOTION_MEDIUM);
+        return appSharedPrefs.getInt(CAMERA_SENSITIVITY, LuminanceMotionDetector.MOTION_MEDIUM);
     }
-    
+
     public void activateFlash(boolean active) {
-    	prefsEditor.putBoolean(FLASH_ACTIVE, active);
-    	prefsEditor.commit();
+        prefsEditor.putBoolean(FLASH_ACTIVE, active);
+        prefsEditor.commit();
     }
-    
+
     public boolean getFlashActivation() {
-    	return appSharedPrefs.getBoolean(FLASH_ACTIVE, false);
+        return appSharedPrefs.getBoolean(FLASH_ACTIVE, false);
     }
-    
+
     public void activateMicrophone(boolean active) {
-    	prefsEditor.putBoolean(MICROPHONE_ACTIVE, active);
-    	prefsEditor.commit();
+        prefsEditor.putBoolean(MICROPHONE_ACTIVE, active);
+        prefsEditor.commit();
     }
-    
+
     public boolean getMicrophoneActivation() {
-    	return appSharedPrefs.getBoolean(MICROPHONE_ACTIVE, true);
+        return appSharedPrefs.getBoolean(MICROPHONE_ACTIVE, true);
     }
-    
+
     public void setMicrophoneSensitivity(String sensitivity) {
-    	prefsEditor.putString(MICROPHONE_SENSITIVITY, sensitivity);
-    	prefsEditor.commit();
+        prefsEditor.putString(MICROPHONE_SENSITIVITY, sensitivity);
+        prefsEditor.commit();
     }
-    
+
     public String getMicrophoneSensitivity() {
-    	return appSharedPrefs.getString(MICROPHONE_SENSITIVITY, MEDIUM);
+        return appSharedPrefs.getString(MICROPHONE_SENSITIVITY, MEDIUM);
     }
-    
+
     public void activateSms(boolean active) {
-    	prefsEditor.putBoolean(SMS_ACTIVE, active);
-    	prefsEditor.commit();
+        prefsEditor.putBoolean(SMS_ACTIVE, active);
+        prefsEditor.commit();
     }
-    
+
     public boolean getSmsActivation() {
-    	return appSharedPrefs.getBoolean(SMS_ACTIVE, false);
+        return appSharedPrefs.getBoolean(SMS_ACTIVE, false);
     }
-    
+
     public void setSmsNumber(String number) {
 
-    	prefsEditor.putString(SMS_NUMBER, number);
-    	prefsEditor.commit();
+        prefsEditor.putString(SMS_NUMBER, number);
+        prefsEditor.commit();
     }
-    
+
     public String getSmsNumber() {
-    	return appSharedPrefs.getString(SMS_NUMBER, "");
+        return appSharedPrefs.getString(SMS_NUMBER, "");
+    }
+
+    public void activateHeartbeat(boolean active) {
+        prefsEditor.putBoolean(HEARTBEAT_MONITOR_ACTIVE, active);
+        prefsEditor.commit();
+    }
+
+    public void setHeartbeatMonitorNotifications (int notificationTimeMs) {
+        prefsEditor.putInt(HEARTBEAT_MONITOR_DELAY,notificationTimeMs);
+        prefsEditor.commit();
+    }
+
+    public boolean getHeartbeatActive() {
+        return appSharedPrefs.getBoolean(HEARTBEAT_MONITOR_ACTIVE, false);
+    }
+
+    public int getHeartbeatNotificationTimeMs () {
+        return appSharedPrefs.getInt(HEARTBEAT_MONITOR_DELAY,300000);
     }
 
     public int getTimerDelay ()
@@ -261,9 +281,9 @@ public class PreferenceManager {
     }
 
     public String getDirPath() {
-    	return DIR_PATH;
+        return DIR_PATH;
     }
-    
+
     public String getSMSText() {
         return context.getString(R.string.intrusion_detected);
     }

--- a/src/main/java/org/havenapp/main/PreferenceManager.java
+++ b/src/main/java/org/havenapp/main/PreferenceManager.java
@@ -28,10 +28,10 @@ import org.havenapp.main.sensors.motion.LuminanceMotionDetector;
 
 
 public class PreferenceManager {
-
+	
     private SharedPreferences appSharedPrefs;
     private Editor prefsEditor;
-
+    
     public static final String LOW = "Low";
     public static final String MEDIUM = "Medium";
     public static final String HIGH = "High";
@@ -41,7 +41,7 @@ public class PreferenceManager {
     public static final String FRONT = "Front";
     public static final String BACK = "Back";
     public static final String NONE = "None";
-
+	
     private static final String APP_SHARED_PREFS="org.havenapp.main";
     private static final String ACCELEROMETER_ACTIVE="accelerometer_active";
     private static final String ACCELEROMETER_SENSITIVITY="accelerometer_sensibility";
@@ -49,9 +49,9 @@ public class PreferenceManager {
     public static final String CAMERA="camera";
     public static final String CAMERA_SENSITIVITY="camera_sensitivity";
     public static final String CONFIG_MOVEMENT ="config_movement";
+    public static final String HEARTBEAT_MONITOR_ACTIVE="heartbeat_monitor_active";
+    public static final String HEARTBEAT_MONITOR_DELAY="heartbeat_monitor_delay";
     private static final String FLASH_ACTIVE="flash_active";
-    public static final String  HEARTBEAT_MONITOR_ACTIVE="heartbeat_monitor_active";
-    public static final String  HEARTBEAT_MONITOR_DELAY="heartbeat_monitor_delay";
     private static final String MICROPHONE_ACTIVE="microphone_active";
     private static final String MICROPHONE_SENSITIVITY="microphone_sensitivity";
     public static final String CONFIG_SOUND = "config_sound";
@@ -62,10 +62,10 @@ public class PreferenceManager {
     public static final String VERIFY_SIGNAL = "verify_signal";
     public static final String SEND_SMS = "send_sms";
     private static final String UNLOCK_CODE="unlock_code";
-
+	
     private static final String ACCESS_TOKEN="access_token";
     private static final String DELEGATED_ACCESS_TOKEN="deferred_access_token";
-
+	
     private static final String PHONE_ID="phone_id";
     private static final String TIMER_DELAY="timer_delay";
     private static final String VIDEO_LENGTH="video_length";
@@ -85,7 +85,7 @@ public class PreferenceManager {
     public static final String DISABLE_BATTERY_OPT = "config_battery_optimizations";
 
     private Context context;
-
+	
     public PreferenceManager(Context context) {
         this.context = context;
         this.appSharedPrefs = context.getSharedPreferences(APP_SHARED_PREFS, Activity.MODE_PRIVATE);
@@ -141,21 +141,21 @@ public class PreferenceManager {
     }
 
     public void activateAccelerometer(boolean active) {
-        prefsEditor.putBoolean(ACCELEROMETER_ACTIVE, active);
-        prefsEditor.commit();
+    	prefsEditor.putBoolean(ACCELEROMETER_ACTIVE, active);
+    	prefsEditor.commit();
     }
-
+    
     public boolean getAccelerometerActivation() {
-        return appSharedPrefs.getBoolean(ACCELEROMETER_ACTIVE, true);
+    	return appSharedPrefs.getBoolean(ACCELEROMETER_ACTIVE, true);
     }
-
+    
     public void setAccelerometerSensitivity(String sensitivity) {
-        prefsEditor.putString(ACCELEROMETER_SENSITIVITY, sensitivity);
-        prefsEditor.commit();
+    	prefsEditor.putString(ACCELEROMETER_SENSITIVITY, sensitivity);
+    	prefsEditor.commit();
     }
-
+    
     public String getAccelerometerSensitivity() {
-        return appSharedPrefs.getString(ACCELEROMETER_SENSITIVITY, HIGH);
+    	return appSharedPrefs.getString(ACCELEROMETER_SENSITIVITY, HIGH);
     }
 
     public void setActivateVideoMonitoring(boolean active) {
@@ -168,94 +168,76 @@ public class PreferenceManager {
     }
 
     public void activateCamera(boolean active) {
-        prefsEditor.putBoolean(CAMERA_ACTIVE, active);
-        prefsEditor.commit();
+    	prefsEditor.putBoolean(CAMERA_ACTIVE, active);
+    	prefsEditor.commit();
     }
-
+    
     public boolean getCameraActivation() {
-        return appSharedPrefs.getBoolean(CAMERA_ACTIVE, true);
+    	return appSharedPrefs.getBoolean(CAMERA_ACTIVE, true);
     }
-
+    
     public void setCamera(String camera) {
-        prefsEditor.putString(CAMERA, camera);
-        prefsEditor.commit();
+    	prefsEditor.putString(CAMERA, camera);
+    	prefsEditor.commit();
     }
-
+    
     public String getCamera() {
-        return appSharedPrefs.getString(CAMERA, FRONT);
+    	return appSharedPrefs.getString(CAMERA, FRONT);
     }
-
+    
     public void setCameraSensitivity(int sensitivity) {
-        prefsEditor.putInt(CAMERA_SENSITIVITY, sensitivity);
-        prefsEditor.commit();
+    	prefsEditor.putInt(CAMERA_SENSITIVITY, sensitivity);
+    	prefsEditor.commit();
     }
-
+    
     public int getCameraSensitivity() {
-        return appSharedPrefs.getInt(CAMERA_SENSITIVITY, LuminanceMotionDetector.MOTION_MEDIUM);
+    	return appSharedPrefs.getInt(CAMERA_SENSITIVITY, LuminanceMotionDetector.MOTION_MEDIUM);
     }
-
+    
     public void activateFlash(boolean active) {
-        prefsEditor.putBoolean(FLASH_ACTIVE, active);
-        prefsEditor.commit();
+    	prefsEditor.putBoolean(FLASH_ACTIVE, active);
+    	prefsEditor.commit();
     }
-
+    
     public boolean getFlashActivation() {
-        return appSharedPrefs.getBoolean(FLASH_ACTIVE, false);
+    	return appSharedPrefs.getBoolean(FLASH_ACTIVE, false);
     }
-
+    
     public void activateMicrophone(boolean active) {
-        prefsEditor.putBoolean(MICROPHONE_ACTIVE, active);
-        prefsEditor.commit();
+    	prefsEditor.putBoolean(MICROPHONE_ACTIVE, active);
+    	prefsEditor.commit();
     }
-
+    
     public boolean getMicrophoneActivation() {
-        return appSharedPrefs.getBoolean(MICROPHONE_ACTIVE, true);
+    	return appSharedPrefs.getBoolean(MICROPHONE_ACTIVE, true);
     }
-
+    
     public void setMicrophoneSensitivity(String sensitivity) {
-        prefsEditor.putString(MICROPHONE_SENSITIVITY, sensitivity);
-        prefsEditor.commit();
+    	prefsEditor.putString(MICROPHONE_SENSITIVITY, sensitivity);
+    	prefsEditor.commit();
     }
-
+    
     public String getMicrophoneSensitivity() {
-        return appSharedPrefs.getString(MICROPHONE_SENSITIVITY, MEDIUM);
+    	return appSharedPrefs.getString(MICROPHONE_SENSITIVITY, MEDIUM);
     }
-
+    
     public void activateSms(boolean active) {
-        prefsEditor.putBoolean(SMS_ACTIVE, active);
-        prefsEditor.commit();
+    	prefsEditor.putBoolean(SMS_ACTIVE, active);
+    	prefsEditor.commit();
     }
-
+    
     public boolean getSmsActivation() {
-        return appSharedPrefs.getBoolean(SMS_ACTIVE, false);
+    	return appSharedPrefs.getBoolean(SMS_ACTIVE, false);
     }
-
+    
     public void setSmsNumber(String number) {
 
-        prefsEditor.putString(SMS_NUMBER, number);
-        prefsEditor.commit();
+    	prefsEditor.putString(SMS_NUMBER, number);
+    	prefsEditor.commit();
     }
-
+    
     public String getSmsNumber() {
-        return appSharedPrefs.getString(SMS_NUMBER, "");
-    }
-
-    public void activateHeartbeat(boolean active) {
-        prefsEditor.putBoolean(HEARTBEAT_MONITOR_ACTIVE, active);
-        prefsEditor.commit();
-    }
-
-    public void setHeartbeatMonitorNotifications (int notificationTimeMs) {
-        prefsEditor.putInt(HEARTBEAT_MONITOR_DELAY,notificationTimeMs);
-        prefsEditor.commit();
-    }
-
-    public boolean getHeartbeatActive() {
-        return appSharedPrefs.getBoolean(HEARTBEAT_MONITOR_ACTIVE, false);
-    }
-
-    public int getHeartbeatNotificationTimeMs () {
-        return appSharedPrefs.getInt(HEARTBEAT_MONITOR_DELAY,300000);
+    	return appSharedPrefs.getString(SMS_NUMBER, "");
     }
 
     public int getTimerDelay ()
@@ -281,9 +263,9 @@ public class PreferenceManager {
     }
 
     public String getDirPath() {
-        return DIR_PATH;
+    	return DIR_PATH;
     }
-
+    
     public String getSMSText() {
         return context.getString(R.string.intrusion_detected);
     }
@@ -315,6 +297,24 @@ public class PreferenceManager {
     public void setNotificationTimeMs (int notificationTimeMs) {
         prefsEditor.putInt(NOTIFICATION_TIME,notificationTimeMs);
         prefsEditor.commit();
+    }
+
+    public void activateHeartbeat(boolean active) {
+        prefsEditor.putBoolean(HEARTBEAT_MONITOR_ACTIVE, active);
+        prefsEditor.commit();
+    }
+
+    public void setHeartbeatMonitorNotifications (int notificationTimeMs) {
+        prefsEditor.putInt(HEARTBEAT_MONITOR_DELAY,notificationTimeMs);
+        prefsEditor.commit();
+    }
+
+    public boolean getHeartbeatActive() {
+        return appSharedPrefs.getBoolean(HEARTBEAT_MONITOR_ACTIVE, false);
+    }
+
+    public int getHeartbeatNotificationTimeMs () {
+        return appSharedPrefs.getInt(HEARTBEAT_MONITOR_DELAY,300000);
     }
 
 }

--- a/src/main/java/org/havenapp/main/SettingsFragment.java
+++ b/src/main/java/org/havenapp/main/SettingsFragment.java
@@ -120,13 +120,14 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
             ((SwitchPreferenceCompat) findPreference(PreferenceManager.HEARTBEAT_MONITOR_ACTIVE)).setChecked(true);
             boolean heartOn = ((SwitchPreferenceCompat) findPreference(PreferenceManager.HEARTBEAT_MONITOR_ACTIVE)).isChecked();
             boolean isMonitoring = preferences.getHeartbeatActive();
-            if (heartOn || isMonitoring) {
+
+            if (heartOn || isMonitoring) { //Check for stray timers/monitors
                 preferences.activateHeartbeat(true);
                 findPreference(PreferenceManager.HEARTBEAT_MONITOR_DELAY).setSummary(preferences.getHeartbeatNotificationTimeMs() / 60000 + " " + getString(R.string.minutes));
             }
             else{
-                findPreference(PreferenceManager.HEARTBEAT_MONITOR_DELAY).setSummary(R.string.heartbeat_time_dialog);
                 preferences.activateHeartbeat(false);
+                findPreference(PreferenceManager.HEARTBEAT_MONITOR_DELAY).setSummary(R.string.heartbeat_time_dialog);
             }
         }
 

--- a/src/main/java/org/havenapp/main/SettingsFragment.java
+++ b/src/main/java/org/havenapp/main/SettingsFragment.java
@@ -115,11 +115,6 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
             findPreference(PreferenceManager.REGISTER_SIGNAL).setSummary(R.string.register_signal_desc);
         }
 
-        if (preferences.getNotificationTimeMs()>0)
-        {
-            findPreference(PreferenceManager.NOTIFICATION_TIME).setSummary(preferences.getNotificationTimeMs()/60000 + " " + getString(R.string.minutes));
-        }
-
         if (preferences.getHeartbeatActive())
         {
             ((SwitchPreferenceCompat) findPreference(PreferenceManager.HEARTBEAT_MONITOR_ACTIVE)).setChecked(true);
@@ -131,12 +126,13 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
             }
             else{
                 findPreference(PreferenceManager.HEARTBEAT_MONITOR_DELAY).setSummary(R.string.heartbeat_time_dialog);
+                preferences.activateHeartbeat(false);
             }
         }
 
-        if (preferences.getHeartbeatNotificationTimeMs()>0 )
+        if (preferences.getHeartbeatNotificationTimeMs()> 300000)
         {
-            findPreference(PreferenceManager.HEARTBEAT_MONITOR_DELAY).setSummary(preferences.getHeartbeatNotificationTimeMs()/60000 + " " + getString(R.string.minutes));
+            findPreference(PreferenceManager.HEARTBEAT_MONITOR_DELAY).setSummary(preferences.getHeartbeatNotificationTimeMs() / 60000 + " " + getString(R.string.minutes));
         }
 
         Preference prefCameraSensitivity = findPreference(PreferenceManager.CAMERA_SENSITIVITY);
@@ -396,6 +392,9 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
                 try {
                     String text = ((EditTextPreference) findPreference(PreferenceManager.HEARTBEAT_MONITOR_DELAY)).getText();
                     int notificationTimeMs = Integer.parseInt(text) * 60000;
+                    if (notificationTimeMs <= 0)
+                        notificationTimeMs = 300000;
+
                     preferences.setHeartbeatMonitorNotifications(notificationTimeMs);
                     findPreference(PreferenceManager.HEARTBEAT_MONITOR_DELAY).setSummary(preferences.getHeartbeatNotificationTimeMs() / 60000 + " " + getString(R.string.minutes));
 

--- a/src/main/java/org/havenapp/main/SettingsFragment.java
+++ b/src/main/java/org/havenapp/main/SettingsFragment.java
@@ -115,6 +115,11 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
             findPreference(PreferenceManager.REGISTER_SIGNAL).setSummary(R.string.register_signal_desc);
         }
 
+        if (preferences.getNotificationTimeMs()>0)
+        {
+            findPreference(PreferenceManager.NOTIFICATION_TIME).setSummary(preferences.getNotificationTimeMs()/60000 + " " + getString(R.string.minutes));
+        }
+
         if (preferences.getHeartbeatActive())
         {
             ((SwitchPreferenceCompat) findPreference(PreferenceManager.HEARTBEAT_MONITOR_ACTIVE)).setChecked(true);
@@ -204,11 +209,8 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
 
         preferences.setActivateVideoMonitoring(videoMonitoringActive);
 
-        boolean heartbeatMonitorActive = ((SwitchPreferenceCompat) findPreference(PreferenceManager.HEARTBEAT_MONITOR_ACTIVE)).isChecked();
-        
-        preferences.activateHeartbeat(heartbeatMonitorActive);
-
         boolean remoteAccessActive = ((SwitchPreferenceCompat) findPreference(PreferenceManager.REMOTE_ACCESS_ACTIVE)).isChecked();
+
         preferences.activateRemoteAccess(remoteAccessActive);
         String password = ((EditTextPreference) findPreference(PreferenceManager.REMOTE_ACCESS_CRED)).getText();
 
@@ -217,6 +219,10 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
             app.stopServer();
             app.startServer();
         }
+
+        boolean heartbeatMonitorActive = ((SwitchPreferenceCompat) findPreference(PreferenceManager.HEARTBEAT_MONITOR_ACTIVE)).isChecked();
+
+        preferences.activateHeartbeat(heartbeatMonitorActive);
 
         mActivity.setResult(Activity.RESULT_OK);
         mActivity.finish();

--- a/src/main/java/org/havenapp/main/model/EventTrigger.java
+++ b/src/main/java/org/havenapp/main/model/EventTrigger.java
@@ -49,6 +49,7 @@ public class EventTrigger extends SugarRecord {
      * Power change detected message
      */
     public static final int POWER = 5;
+
     /**
      * Significant motion detected message
      */
@@ -58,6 +59,11 @@ public class EventTrigger extends SugarRecord {
      * Significant motion detected message
      */
     public static final int CAMERA_VIDEO = 7;
+    
+    /**
+     * Heartbeat notification message
+     */
+    public static final int HEART = 8;
 
 
     public EventTrigger ()
@@ -119,6 +125,9 @@ public class EventTrigger extends SugarRecord {
                 break;
             case EventTrigger.CAMERA_VIDEO:
                 sType = context.getString(R.string.sensor_camera_video);
+                break;
+            case EventTrigger.HEART:
+                sType = context.getString(R.string.sensor_heartbeat);
                 break;
             default:
                 sType = context.getString(R.string.sensor_unknown);

--- a/src/main/java/org/havenapp/main/service/SignalSender.java
+++ b/src/main/java/org/havenapp/main/service/SignalSender.java
@@ -24,9 +24,7 @@ public class SignalSender {
     private Context mContext;
     private static SignalSender mInstance;
     private String mUsername; //aka your signal phone number
-    private String emojiString;
     private CountDownTimer mCountdownTimer;
-    private PreferenceManager preferences;
 
     private SignalSender(Context context, String username)
     {
@@ -99,8 +97,7 @@ public class SignalSender {
 
     public void startHeartbeatTimer (int countMs)
     {
-        //Set default to 5 minutes, catch dangerous Signal thresholds
-        if (countMs <= 10000)
+        if (countMs <= 10000) //Default if '0' setting
             countMs = 300000;
 
         mCountdownTimer =  new CountDownTimer(countMs,1000) {
@@ -119,15 +116,15 @@ public class SignalSender {
 
     private void beatingHeart ()
     {
-        preferences = new PreferenceManager(mContext);
+        PreferenceManager preferences = new PreferenceManager(mContext);
         int unicodeBeat = 0x1F493;
-        emojiString = new String(Character.toChars(unicodeBeat));
+        String emojiString = new String(Character.toChars(unicodeBeat));
 
         if (!TextUtils.isEmpty(mUsername)) {
-            SignalSender sender = SignalSender.getInstance(mContext, mUsername.trim());
-            ArrayList<String> recip = new ArrayList<>();
-            recip.add(preferences.getSmsNumber());
-            sender.sendMessage(recip, emojiString,null);
+            getInstance(mContext, mUsername.trim());
+            ArrayList<String> recipient = new ArrayList<>();
+            recipient.add(preferences.getSmsNumber());
+            sendMessage(recipient, emojiString,null);
         }
         else if (!TextUtils.isEmpty(preferences.getSmsNumber())) {
 
@@ -136,7 +133,6 @@ public class SignalSender {
             StringTokenizer st = new StringTokenizer(preferences.getSmsNumber(),",");
             while (st.hasMoreTokens())
                 manager.sendTextMessage(st.nextToken(), null, emojiString, null, null);
-
         }
     }
 

--- a/src/main/java/org/havenapp/main/service/SignalSender.java
+++ b/src/main/java/org/havenapp/main/service/SignalSender.java
@@ -2,12 +2,18 @@ package org.havenapp.main.service;
 
 import android.content.Context;
 
+import android.os.CountDownTimer;
+import android.telephony.SmsManager;
+import android.text.TextUtils;
+import android.util.Log;
 import net.sourceforge.argparse4j.inf.Namespace;
 
 import org.asamk.signal.Main;
+import org.havenapp.main.PreferenceManager;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.StringTokenizer;
 
 /**
  * Created by n8fr8 on 11/6/17.
@@ -18,6 +24,8 @@ public class SignalSender {
     private Context mContext;
     private static SignalSender mInstance;
     private String mUsername; //aka your signal phone number
+    private CountDownTimer mCountdownTimer;
+    private PreferenceManager preferences;
 
     private SignalSender(Context context, String username)
     {
@@ -79,6 +87,57 @@ public class SignalSender {
                 mainSignal.handleCommands(ns);
             }
         });
+    }
+
+    public void stopHeartbeatTimer ()
+    {
+        mCountdownTimer.cancel();
+        mCountdownTimer = null;
+        Log.d("HEARTBEAT TIMER", "Stopped" );
+
+    }
+
+    public void startHeartbeatTimer (int countMs)
+    {
+        //Set default to 5 minutes, catch dangerous Signal thresholds
+        if (countMs <= 10000)
+            countMs = 300000;
+
+        mCountdownTimer =  new CountDownTimer(countMs,1000) {
+
+            public void onTick(long millisUntilFinished) {
+                Log.d("HEARTBEAT TIMER"," seconds remaining: " + millisUntilFinished / 1000);
+            }
+
+            public void onFinish() {
+                Log.d("HEARTBEAT TIMER"," Done, update message sent!");
+                beatingHeart();
+                start();
+            }
+        }.start();
+    }
+
+    private void beatingHeart ()
+    {
+        preferences = new PreferenceManager(mContext);
+        int unicodeBeat = 0x1F493;
+        String emojiString = new String(Character.toChars(unicodeBeat));
+
+        if (!TextUtils.isEmpty(mUsername)) {
+            SignalSender sender = SignalSender.getInstance(mContext, mUsername.trim());
+            ArrayList<String> recip = new ArrayList<>();
+            recip.add(preferences.getSmsNumber());
+            sender.sendMessage(recip, emojiString,null);
+        }
+        else if (!TextUtils.isEmpty(preferences.getSmsNumber())) {
+
+            SmsManager manager = SmsManager.getDefault();
+
+            StringTokenizer st = new StringTokenizer(preferences.getSmsNumber(),",");
+            while (st.hasMoreTokens())
+                manager.sendTextMessage(st.nextToken(), null, emojiString, null, null);
+
+        }
     }
 
     public void sendMessage (final ArrayList<String> recipients, final String message, final String attachment)

--- a/src/main/java/org/havenapp/main/service/SignalSender.java
+++ b/src/main/java/org/havenapp/main/service/SignalSender.java
@@ -24,6 +24,7 @@ public class SignalSender {
     private Context mContext;
     private static SignalSender mInstance;
     private String mUsername; //aka your signal phone number
+    private String emojiString;
     private CountDownTimer mCountdownTimer;
     private PreferenceManager preferences;
 
@@ -94,7 +95,6 @@ public class SignalSender {
         mCountdownTimer.cancel();
         mCountdownTimer = null;
         Log.d("HEARTBEAT TIMER", "Stopped" );
-
     }
 
     public void startHeartbeatTimer (int countMs)
@@ -121,7 +121,7 @@ public class SignalSender {
     {
         preferences = new PreferenceManager(mContext);
         int unicodeBeat = 0x1F493;
-        String emojiString = new String(Character.toChars(unicodeBeat));
+        emojiString = new String(Character.toChars(unicodeBeat));
 
         if (!TextUtils.isEmpty(mUsername)) {
             SignalSender sender = SignalSender.getInstance(mContext, mUsername.trim());

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -78,6 +78,9 @@
     <string name="save_number">Save Number</string>
 
     <string name="action_cancel">Deactivate</string>
+    <string name="power_optim_status_on">Optimization Activated</string>
+    <string name="power_optim_status_off">Optimization Deactivated</string>
+    <string name="power_optim_status_unsupported">Unsupported for this device</string>
     <string name="status_on">ACTIVE</string>
     <string name="status_charging">Charging:</string>
     <string name="you_will_receive_a_text_when_the_app_hears_or_sees_something">You will receive a text when the app hears or sees something</string>
@@ -109,10 +112,12 @@
     <string name="sensor_power">USB Power</string>
     <string name="sensor_bump">Bump (Accelerometer)</string>
     <string name="sensor_camera_video">Motion (Video)</string>
+    <string name="sensor_heartbeat">Heartbeat</string>
     <string name="sensor_unknown">Unknown</string>
 
     <string name="settings">Settings</string>
     <string name="remote_access_onion_error">This feature requires the Orbot: Tor for Android app to be installed.</string>
+    <string name="remote_access_onion_error_pw">This feature requires you to set a remote password.</string>
 
     <!--Preference Settings -->
     <string name="hint_number" translatable="false">+12125551212</string>
@@ -139,10 +144,21 @@
     <string name="notification_time_summary">Only send notifications at configured interval</string>
     <string name="notification_time_dialog">Enter time (minutes) to limit notifications. \'0\' to send every notification.</string>
     <string name="minutes">minutes(s)</string>
+    <string name="seconds">second(s)</string>
     <string name="keep_watch">Keep Watch!</string>
     <string name="camera_sensitivity_tip">Switch camera or use the slider to adjust motion detection sensitivity</string>
     <string name="disable_battery_opt_title">Disable Battery Optimizations</string>
     <string name="disable_battery_opt_summary">Allow app to run when screen is off</string>
 
+    <string name="hearbeat_monitor">Heartbeat Notifications</string>
+    <string name="hearbeat_monitor_enable">Enable Heartbeat Monitor</string>
+    <string name="hearbeat_monitor_summary">Set Monitor Alert Interval</string>
+    <string name="heartbeat_time_dialog">Enter time (minutes) to limit heartbeat notifications. Minimum delay is 5.</string>
+    <string name="hearbeat_monitor_dialog">Send monitor status icon messages</string>
+    <string name="thumbsUp"><node>&#x1f44d;</node></string>
+    <string name="beatingHeart"><node>&#x1F493;</node></string>
+    <string name="brokenHeart"><node>&#x1F494;</node></string>
+    <string name="beatingHeartUnicode">0x1F493</string>
+    <string name="brokenHeartUnicode">0x1F494</string>
 
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -153,12 +153,7 @@
     <string name="hearbeat_monitor">Heartbeat Notifications</string>
     <string name="hearbeat_monitor_enable">Enable Heartbeat Monitor</string>
     <string name="hearbeat_monitor_summary">Set Monitor Alert Interval</string>
-    <string name="heartbeat_time_dialog">Enter time (minutes) to send heartbeat notifications. Minimum recommended delay is 5 minutes.</string>
+    <string name="heartbeat_time_dialog">Enter time (minutes) to send heartbeat notifications. Default is 5 minutes, the minimum is 1.</string>
     <string name="hearbeat_monitor_dialog">Send status icon messages</string>
-    <string name="thumbsUp"><node>&#x1f44d;</node></string>
-    <string name="beatingHeart"><node>&#x1F493;</node></string>
-    <string name="brokenHeart"><node>&#x1F494;</node></string>
-    <string name="beatingHeartUnicode">0x1F493</string>
-    <string name="brokenHeartUnicode">0x1F494</string>
-
+    
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -78,9 +78,6 @@
     <string name="save_number">Save Number</string>
 
     <string name="action_cancel">Deactivate</string>
-    <string name="power_optim_status_on">Optimization Activated</string>
-    <string name="power_optim_status_off">Optimization Deactivated</string>
-    <string name="power_optim_status_unsupported">Unsupported for this device</string>
     <string name="status_on">ACTIVE</string>
     <string name="status_charging">Charging:</string>
     <string name="you_will_receive_a_text_when_the_app_hears_or_sees_something">You will receive a text when the app hears or sees something</string>
@@ -117,7 +114,6 @@
 
     <string name="settings">Settings</string>
     <string name="remote_access_onion_error">This feature requires the Orbot: Tor for Android app to be installed.</string>
-    <string name="remote_access_onion_error_pw">This feature requires you to set a remote password.</string>
 
     <!--Preference Settings -->
     <string name="hint_number" translatable="false">+12125551212</string>
@@ -144,16 +140,15 @@
     <string name="notification_time_summary">Only send notifications at configured interval</string>
     <string name="notification_time_dialog">Enter time (minutes) to limit notifications. \'0\' to send every notification.</string>
     <string name="minutes">minutes(s)</string>
-    <string name="seconds">second(s)</string>
     <string name="keep_watch">Keep Watch!</string>
     <string name="camera_sensitivity_tip">Switch camera or use the slider to adjust motion detection sensitivity</string>
     <string name="disable_battery_opt_title">Disable Battery Optimizations</string>
     <string name="disable_battery_opt_summary">Allow app to run when screen is off</string>
 
-    <string name="hearbeat_monitor">Heartbeat Notifications</string>
-    <string name="hearbeat_monitor_enable">Enable Heartbeat Monitor</string>
-    <string name="hearbeat_monitor_summary">Set Monitor Alert Interval</string>
-    <string name="heartbeat_time_dialog">Enter time (minutes) to send heartbeat notifications. Default is 5 minutes, the minimum is 1.</string>
-    <string name="hearbeat_monitor_dialog">Send status icon messages</string>
+    <string name="hearbeat_monitor">Heartbeat Monitor</string>
+    <string name="hearbeat_monitor_enable">Enable Heartbeat Notifications</string>
+    <string name="hearbeat_monitor_summary">Send status messages at a configured interval</string>
+    <string name="heartbeat_time_dialog">Enter time (minutes) to monitor the app status. Default 5 minutes; minimum of 1.</string>
+    <string name="hearbeat_monitor_dialog">Send alerts while the app is active</string>
     
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -153,8 +153,8 @@
     <string name="hearbeat_monitor">Heartbeat Notifications</string>
     <string name="hearbeat_monitor_enable">Enable Heartbeat Monitor</string>
     <string name="hearbeat_monitor_summary">Set Monitor Alert Interval</string>
-    <string name="heartbeat_time_dialog">Enter time (minutes) to limit heartbeat notifications. Minimum delay is 5.</string>
-    <string name="hearbeat_monitor_dialog">Send monitor status icon messages</string>
+    <string name="heartbeat_time_dialog">Enter time (minutes) to send heartbeat notifications. Minimum recommended delay is 5 minutes.</string>
+    <string name="hearbeat_monitor_dialog">Send status icon messages</string>
     <string name="thumbsUp"><node>&#x1f44d;</node></string>
     <string name="beatingHeart"><node>&#x1F493;</node></string>
     <string name="brokenHeart"><node>&#x1F494;</node></string>

--- a/src/main/res/xml/settings.xml
+++ b/src/main/res/xml/settings.xml
@@ -89,6 +89,22 @@
             android:title="@string/notification_time"
             />
 
+    </PreferenceCategory>
+    <PreferenceCategory android:title="@string/hearbeat_monitor">
+
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="heartbeat_monitor_active"
+            android:title="@string/hearbeat_monitor_enable" />
+
+        <EditTextPreference
+            style="@style/AppPreference.DialogPreferenceSave"
+            android:dialogLayout="@layout/pref_dialog_edit_text"
+            android:dialogMessage="@string/heartbeat_time_dialog"
+            android:inputType="number"
+            android:key="heartbeat_monitor_delay"
+            android:summary="@string/hearbeat_monitor_dialog"
+            android:title="@string/hearbeat_monitor_summary"/>
 
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/remote_access">


### PR DESCRIPTION
### Feature Description 
**Review, feedback and/or modification appreciated**

Fills feature request from #54

- Option to send beating heart emoji while the app is active.
- Timer setting, minimum 1 minute and defaults to 5.
- Sent to the saved phone number via Signal as: 💓
- Used JNI compatible strings to avoid parsing errors on lower Android versions instead of adding the `EmojiCompat` dependency

**Opportunities:**
- Could be tied into the MonitorService to send a 💔 broken heart on some exceptions


