### PR TITLE
Fix unescaped characters, update build settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-alpha08'
+        classpath 'com.android.tools.build:gradle:3.2.0-alpha12'
 
     }
 
@@ -120,8 +120,7 @@ dependencies {
     implementation 'com.maxproj.simplewaveform:app:1.0.0'
     implementation 'com.takisoft.fix:preference-v7:27.1.0.0'
     implementation 'com.wdullaer:materialdatetimepicker:3.5.2'
-
-    compile 'com.googlecode.libphonenumber:libphonenumber:8.7.0'
+    implementation 'com.googlecode.libphonenumber:libphonenumber:8.7.0'
     implementation('com.mikepenz:aboutlibraries:6.0.2@aar') {
         transitive = true
     }

--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.1.0'
     implementation 'com.android.support:design:27.1.0'
     implementation 'com.android.support:cardview-v7:27.1.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.0'
     implementation 'com.github.guardianproject:signal-cli-android:-SNAPSHOT'
     implementation 'com.github.satyan:sugar:1.5'
     implementation 'com.squareup.picasso:picasso:2.5.2'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-alpha12'
+        classpath 'com.android.tools.build:gradle:3.2.0-alpha13'
 
     }
 

--- a/src/main/res/values-pt/strings.xml
+++ b/src/main/res/values-pt/strings.xml
@@ -96,7 +96,7 @@
     <string name="cancel">Cancelar</string>
     <string name="register_title">Registar com Signal</string>
     <string name="register_signal_desc">
-        Registar o novo número de telefone (+351912223344) com a aplicação Signal para proteger as notificaçãos. NÃO USAR O SEU NÚMERO \'SIGNAL' ATUAL/PRINCIPAL.</string>
+        Registar o novo número de telefone (+351912223344) com a aplicação Signal para proteger as notificaçãos. NÃO USAR O SEU NÚMERO \'SIGNAL\' ATUAL/PRINCIPAL.</string>
     <string name="phone_hint">+351912223344</string>
 
     <string name="menu_licenses">Licenças...</string>

--- a/src/main/res/values-tr/strings.xml
+++ b/src/main/res/values-tr/strings.xml
@@ -36,7 +36,7 @@
 
     <string name="action_settings">Ayarlar</string>
 
-    <string name="intro1_title">Haven'a Hoşgeldiniz</string>
+    <string name="intro1_title">Haven\'a Hoşgeldiniz</string>
     <string name="intro1_desc">\"Now when the ark of human fate,\nLong baffled by the wayward wind,\nIs drifting with its peopled freight,\nSAFE HAVEN on the height find...\"\n-George Meredith</string>
 
     <string name="intro2_title">Haven; evine, ofisine, otel odasına veya özel alanına izinsiz girişlere karşı tetikte olmak isteyen insanlar içindir</string>
@@ -90,12 +90,12 @@
     <string name="send_test_message">Deneme mesajı gönder</string>
     <string name="verify">Doğrula</string>
     <string name="register">Kaydol</string>
-    <string name="activate_signal">Signal'ı Etkinleştir</string>
-    <string name="verify_signal">Signal'ı Onayla</string>
-    <string name="enter_verification">Signal'a kayıt sırasında gelen mesajdaki onay kodunu girin</string>
+    <string name="activate_signal">Signal\'ı Etkinleştir</string>
+    <string name="verify_signal">Signal\'ı Onayla</string>
+    <string name="enter_verification">Signal\'a kayıt sırasında gelen mesajdaki onay kodunu girin</string>
     <string name="cancel">İptal</string>
-    <string name="register_title">Signal'a Kaydol</string>
-    <string name="register_signal_desc">Bildirimleri göndereceğiniz yeni bir telefon numarasını (+905321234567) Signal'a kaydedin. SIGNAL UYGULAMASINDA MEVCUT/ÖNCEDEN KAYDEDİLMİŞ BİR NUMARA KULLANMAYIN.</string>
+    <string name="register_title">Signal\'a Kaydol</string>
+    <string name="register_signal_desc">Bildirimleri göndereceğiniz yeni bir telefon numarasını (+905321234567) Signal\'a kaydedin. SIGNAL UYGULAMASINDA MEVCUT/ÖNCEDEN KAYDEDİLMİŞ BİR NUMARA KULLANMAYIN.</string>
     <string name="phone_hint">+905321234567</string>
 
     <string name="menu_licenses">Lisans...</string>


### PR DESCRIPTION
- Update to `build:gradle:3.2.0-alpha13` & `constraint-layout:1.1.0 `

- Fix unescaped character errors present in 2 translations.