### PR TITLE
localhost:8888 allows access to logs without Tor: let's announce that.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If you are an Android developer, you can learn more about how you can make use o
 
 ## Why no iPhone Support?
 
-While we hope to support a version of Haven that runs directly on iOS devices in the future, iPhone users can still benefit from Haven today. You can purchase an inexpensive Android phone for less than $100, and use that as your "Haven Device", that you leave behind, while you keep your iPhone with you. If you run Signal on your iPhone, you can configure Haven on Android to send encrypted notifications, with photos and audio, directly to you. If you enable the "Tor Onion Service" feature in Haven (requires either installing "Orbot: proxy for android" app as well, or to manually forward port 8888 with, e.g., ssh in termux), you can remotely access all Haven log data from your iPhone, using the Onion Browser app, or from any [desktop Tor browser](https://www.torproject.org/projects/torbrowser.html).
+While we hope to support a version of Haven that runs directly on iOS devices in the future, iPhone users can still benefit from Haven today. You can purchase an inexpensive Android phone for less than $100, and use that as your "Haven Device", that you leave behind, while you keep your iPhone with you. If you run Signal on your iPhone, you can configure Haven on Android to send encrypted notifications, with photos and audio, directly to you. If you enable the "Tor Onion Service" feature in Haven (requires installing "Orbot" app as well), you can remotely access all Haven log data from your iPhone, using the Onion Browser app.
 
 So, no, iPhone users we didn't forget about you, and hope you'll pick up an Android burner today for a few bucks!
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If you are an Android developer, you can learn more about how you can make use o
 
 ## Why no iPhone Support?
 
-While we hope to support a version of Haven that runs directly on iOS devices in the future, iPhone users can still benefit from Haven today. You can purchase an inexpensive Android phone for less than $100, and use that as your "Haven Device", that you leave behind, while you keep your iPhone with you. If you run Signal on your iPhone, you can configure Haven on Android to send encrypted notifications, with photos and audio, directly to you. If you enable the "Tor Onion Service" feature in Haven (requires installing "Orbot" app as well), you can remotely access all Haven log data from your iPhone, using the Onion Browser app.
+While we hope to support a version of Haven that runs directly on iOS devices in the future, iPhone users can still benefit from Haven today. You can purchase an inexpensive Android phone for less than $100, and use that as your "Haven Device", that you leave behind, while you keep your iPhone with you. If you run Signal on your iPhone, you can configure Haven on Android to send encrypted notifications, with photos and audio, directly to you. If you enable the "Tor Onion Service" feature in Haven (requires either installing "Orbot: proxy for android" app as well, or to manually forward port 8888 with, e.g., ssh in termux), you can remotely access all Haven log data from your iPhone, using the Onion Browser app, or from any [desktop Tor browser](https://www.torproject.org/projects/torbrowser.html).
 
 So, no, iPhone users we didn't forget about you, and hope you'll pick up an Android burner today for a few bucks!
 
@@ -91,7 +91,7 @@ Notifications are sent through a service running in the background that is defin
 
 ### Remote Access
 
-All event logs and captured media can be remotely accessed through a [Tor Onion Service](https://www.torproject.org/docs/onion-services). Haven must be configured as an Onion Service and requires the device to also have [Orbot: Tor for Android](https://guardianproject.info/apps/orbot) installed and running. 
+All event logs and captured media can be remotely accessed. Haven must be configured as an Onion Service. To access logs through a [Tor Onion Service](https://www.torproject.org/docs/onion-services), [Tor: proxy for Android](https://guardianproject.info/apps/orbot) installed and running is required on the device. Access to logs are also available  locally on localhost:8888, you can forward that access with, e.g., ssh from termux.
 
 ## ATTRIBUTIONS
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -113,7 +113,7 @@
     <string name="sensor_unknown">Unknown</string>
 
     <string name="settings">Settings</string>
-    <string name="remote_access_onion_error">This feature requires the Orbot: Tor for Android app to be installed.</string>
+    <string name="remote_access_onion_error">This feature requires the Orbot:proxy for Android app to be installed, or to forward localhost:8888.</string>
 
     <!--Preference Settings -->
     <string name="hint_number" translatable="false">+12125551212</string>


### PR DESCRIPTION
My tor browser[1] failed accessing Haven's logs[2] on the onion server hosted by "Orbot: proxy with tor" [3].
On the point of reporting this, I discovered[4] that Haven's servers was also accessible on localhost:8888. Let's add that in the documentation and in the help text hovering in the app.

[1]: linux64-7.5.3_en-US https://www.torproject.org/projects/torbrowser.html
[2]: 0.1.0-RC-1 installed with google play on android 4.1.1, and also on another phone, on android 6.0
[3]: 16.0.0-RC-2-multi-SDK16 also installed with google play on android 4.1.1, and also on another phone, on android 6.0
[4]: https://github.com/guardianproject/haven/issues/230