### PR TITLE
Share URIs for valid file / file paths only

### DIFF
--- a/src/main/java/org/havenapp/main/ui/EventActivity.java
+++ b/src/main/java/org/havenapp/main/ui/EventActivity.java
@@ -156,6 +156,10 @@ public class EventActivity extends AppCompatActivity {
         //convert from paths to Android friendly Parcelable Uri's
         for (EventTrigger trigger : mEvent.getEventTriggers())
         {
+            // ignore triggers for which we do not have valid file/file-paths
+            if (trigger.getMimeType() == null || trigger.getPath() == null)
+                continue;
+
             File fileIn = new File(trigger.getPath());
             Uri u = Uri.fromFile(fileIn);
             uris.add(u);


### PR DESCRIPTION
While sharing an `Event` consisting of any `EventTrigger`s for which we do not have a file we get a toast "Couldn't attach file". For multiple such triggers in one event the toast persists for a long time. This may result in very disturbing user experience. This PR aims to solve that. 

This will also close #181 since that crash was caused by NPE while attempting to create a `File` from a null string. 