### PR TITLE
Organise media storage by session

### DIFF
--- a/src/main/java/org/havenapp/main/PreferenceManager.java
+++ b/src/main/java/org/havenapp/main/PreferenceManager.java
@@ -26,6 +26,8 @@ import android.content.SharedPreferences.Editor;
 
 import org.havenapp.main.sensors.motion.LuminanceMotionDetector;
 
+import java.io.File;
+
 
 public class PreferenceManager {
 	
@@ -85,6 +87,8 @@ public class PreferenceManager {
     public static final String NOTIFICATION_TIME = "notification_time";
 
     public static final String DISABLE_BATTERY_OPT = "config_battery_optimizations";
+
+    private static final String CURRENT_SESSION = "current_session";
 
     private Context context;
 	
@@ -293,7 +297,7 @@ public class PreferenceManager {
 
     public String getImagePath ()
     {
-        return "/phoneypot";
+        return getDefaultMediaStoragePath();
     }
 
     public int getMaxImages ()
@@ -303,7 +307,11 @@ public class PreferenceManager {
 
     public String getAudioPath ()
     {
-        return "/phoneypot"; //phoneypot is the old code name for Haven
+        return getDefaultMediaStoragePath();
+    }
+
+    private String getDefaultMediaStoragePath() {
+        return "/phoneypot" + File.separator + getCurrentSession(); //phoneypot is the old code name for Haven
     }
 
     public int getAudioLength ()
@@ -338,4 +346,16 @@ public class PreferenceManager {
         return appSharedPrefs.getInt(HEARTBEAT_MONITOR_DELAY,300000);
     }
 
+    /**
+     * Sets a string with the format {@link Utils#DATE_TIME_PATTERN}
+     * representing current date and time for the key {@link #CURRENT_SESSION}
+     */
+    public void setCurrentSession() {
+        prefsEditor.putString(CURRENT_SESSION, Utils.getDateTime(System.currentTimeMillis()));
+        prefsEditor.commit();
+    }
+
+    private String getCurrentSession() {
+        return appSharedPrefs.getString(CURRENT_SESSION, "unknown_session");
+    }
 }

--- a/src/main/java/org/havenapp/main/Utils.java
+++ b/src/main/java/org/havenapp/main/Utils.java
@@ -1,5 +1,7 @@
 package org.havenapp.main;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
@@ -10,6 +12,9 @@ import java.util.concurrent.TimeUnit;
  */
 
 class Utils {
+
+    private static final String DATE_TIME_PATTERN = "yyyy-MM-dd_HH:mm:ss";
+
     static String getTimerText(long milliseconds) {
         String timerText;
         if (TimeUnit.MILLISECONDS.toHours(milliseconds) % 24 == 0) {
@@ -29,5 +34,17 @@ class Utils {
         }
 
         return timerText;
+    }
+
+    /**
+     * Get a user friendly date and time representation from UNIX epoch.
+     * The default {@link Locale} is used.
+     *
+     * @param timeMillis value representing UNIX epoch
+     * @return a string of the format "yyyy-MM-dd_HH:mm:ss" for the corresponding epoch
+     */
+    public static String getDateTime(long timeMillis) {
+        Date date = new Date(timeMillis);
+        return new SimpleDateFormat(DATE_TIME_PATTERN, Locale.getDefault()).format(date);
     }
 }

--- a/src/main/java/org/havenapp/main/service/MonitorService.java
+++ b/src/main/java/org/havenapp/main/service/MonitorService.java
@@ -219,6 +219,8 @@ public class MonitorService extends Service {
     {
         mIsRunning = true;
 
+        mPrefs.setCurrentSession();
+
         if (!mPrefs.getAccelerometerSensitivity().equals(PreferenceManager.OFF)) {
             mAccelManager = new AccelerometerMonitor(this);
             if(Build.VERSION.SDK_INT>=18) {


### PR DESCRIPTION
- directory /phoneypot/<session_identifier> will hold files for session
  represented by session_identifier
- session_identifier is sensor start timestamp for the corresponding
  session
- session_identifier for the current session are overwritten in
  preferences

Aims to close #28 