### PR TITLE
Remove colons & use ISO8601-ish timestamps in files (Fixes #348 and #335)

### DIFF
--- a/src/main/java/org/havenapp/main/Utils.java
+++ b/src/main/java/org/havenapp/main/Utils.java
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeUnit;
 
 class Utils {
 
-    private static final String DATE_TIME_PATTERN = "yyyy-MM-dd_HH:mm:ss";
+    private static final String DATE_TIME_PATTERN = "yyyy-MM-dd_HH-mm-ss";
 
     static String getTimerText(long milliseconds) {
         String timerText;

--- a/src/main/java/org/havenapp/main/Utils.java
+++ b/src/main/java/org/havenapp/main/Utils.java
@@ -11,9 +11,9 @@ import java.util.concurrent.TimeUnit;
  * Class containing util functions which will be used multiple times throughout the app.
  */
 
-class Utils {
+public class Utils {
 
-    private static final String DATE_TIME_PATTERN = "yyyy-MM-dd_HH-mm-ss";
+    public static final String DATE_TIME_PATTERN = "yyyy-MM-dd_HH-mm-ss.SSS";
 
     static String getTimerText(long milliseconds) {
         String timerText;
@@ -41,7 +41,7 @@ class Utils {
      * The default {@link Locale} is used.
      *
      * @param date concerned {@link Date} instance
-     * @return a string of the format "yyyy-MM-dd_HH:mm:ss" for the corresponding date
+     * @return a string of the format "yyyy-MM-dd_HH-mm-ss.SSS" for the corresponding date
      */
     public static String getDateTime(Date date) {
         return new SimpleDateFormat(DATE_TIME_PATTERN, Locale.getDefault()).format(date);

--- a/src/main/java/org/havenapp/main/sensors/media/AudioRecorderTask.java
+++ b/src/main/java/org/havenapp/main/sensors/media/AudioRecorderTask.java
@@ -15,9 +15,13 @@ import android.media.MediaRecorder;
 import android.os.Environment;
 import android.util.Log;
 
-import java.io.File;
-
 import org.havenapp.main.PreferenceManager;
+import org.havenapp.main.Utils;
+
+import java.io.File;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
 
 public class AudioRecorderTask extends Thread {
 	
@@ -69,7 +73,8 @@ public class AudioRecorderTask extends Thread {
 
         File fileFolder = new File(Environment.getExternalStorageDirectory().getPath(),prefs.getDefaultMediaStoragePath());
         fileFolder.mkdirs();
-        audioPath = new File(fileFolder,new java.util.Date().getTime() + ".m4a");
+        audioPath = new File(fileFolder,new SimpleDateFormat(Utils.DATE_TIME_PATTERN,
+				Locale.getDefault()).format(new Date()) + ".m4a");
 
     }
 	

--- a/src/main/java/org/havenapp/main/sensors/motion/CameraViewHolder.java
+++ b/src/main/java/org/havenapp/main/sensors/motion/CameraViewHolder.java
@@ -30,6 +30,7 @@ import android.view.Surface;
 import com.google.android.cameraview.CameraView;
 
 import org.havenapp.main.PreferenceManager;
+import org.havenapp.main.Utils;
 import org.havenapp.main.model.EventTrigger;
 import org.havenapp.main.service.MonitorService;
 import org.jcodec.api.android.AndroidSequenceEncoder;
@@ -37,9 +38,11 @@ import org.jcodec.api.android.AndroidSequenceEncoder;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -145,9 +148,10 @@ public class CameraViewHolder {
                         File fileImageDir = new File(Environment.getExternalStorageDirectory(), prefs.getDefaultMediaStoragePath());
                         fileImageDir.mkdirs();
 
-                        String ts = new Date().getTime() + ".jpg";
+                        String ts = new SimpleDateFormat(Utils.DATE_TIME_PATTERN,
+                                Locale.getDefault()).format(new Date());
 
-                        File fileImage = new File(fileImageDir, "detected.original." + ts);
+                        File fileImage = new File(fileImageDir, ts.concat(".detected.original.jpg"));
                         FileOutputStream stream = new FileOutputStream(fileImage);
                         rawBitmap.compress(Bitmap.CompressFormat.JPEG, 100, stream);
 
@@ -329,7 +333,8 @@ public class CameraViewHolder {
 
 	    if (doingVideoProcessing)
 	        return false;
-        String ts1 = String.valueOf(new Date().getTime());
+        String ts1 = new SimpleDateFormat(Utils.DATE_TIME_PATTERN,
+                Locale.getDefault()).format(new Date());
         File fileStoragePath = new File(Environment.getExternalStorageDirectory(),prefs.getDefaultMediaStoragePath());
         fileStoragePath.mkdirs();
 

--- a/src/main/java/org/havenapp/main/service/WebServer.java
+++ b/src/main/java/org/havenapp/main/service/WebServer.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import org.havenapp.main.R;
+import org.havenapp.main.Utils;
 import org.havenapp.main.model.Event;
 import org.havenapp.main.model.EventTrigger;
 
@@ -14,8 +15,10 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
+import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
@@ -169,7 +172,8 @@ public class WebServer extends NanoHTTPD {
         for (EventTrigger eventTrigger: triggers)
         {
             String title = eventTrigger.getStringType(mContext);
-            String desc = eventTrigger.getTriggerTime().toString();
+            String desc = new SimpleDateFormat(Utils.DATE_TIME_PATTERN,
+                    Locale.getDefault()).format(eventTrigger.getTriggerTime());
 
             page.append("<b>");
             page.append(title).append("</b><br/>");

--- a/src/main/java/org/havenapp/main/ui/EventActivity.java
+++ b/src/main/java/org/havenapp/main/ui/EventActivity.java
@@ -16,11 +16,14 @@ import android.view.MenuItem;
 import android.view.View;
 
 import org.havenapp.main.R;
+import org.havenapp.main.Utils;
 import org.havenapp.main.model.Event;
 import org.havenapp.main.model.EventTrigger;
 
 import java.io.File;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Locale;
 
 public class EventActivity extends AppCompatActivity {
 
@@ -176,7 +179,9 @@ public class EventActivity extends AppCompatActivity {
 
         for (EventTrigger eventTrigger : mEvent.getEventTriggers()) {
 
-            mEventLog.append("Event Triggered @ ").append(eventTrigger.getTriggerTime().toString()).append("\n");
+            mEventLog.append("Event Triggered @ ").append(
+                     new SimpleDateFormat(Utils.DATE_TIME_PATTERN,
+                            Locale.getDefault()).format(eventTrigger.getTriggerTime())).append("\n");
 
             String sType = eventTrigger.getStringType(this);
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -159,4 +159,8 @@
     <string name="config_storage_path">Storage Folder Path</string>
     <string name="config_storage_page_hint">Where captured media is stored</string>
 
+    <!-- accepted digits for directory name -- may vary for locale/platform/etc.
+         Skipping periods, spaces, and other special characters to keep it simple -->
+    <string name="path_chars">0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_/</string>
+
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -159,7 +159,7 @@
     <string name="config_storage_path">Storage Folder Path</string>
     <string name="config_storage_page_hint">Where captured media is stored</string>
 
-    <!-- accepted digits for directory name -- may vary for locale/platform/etc.
+    <!-- accepted digits for directory name - may vary for locale/platform/etc.
          Skipping periods, spaces, and other special characters to keep it simple -->
     <string name="path_chars">0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_/</string>
 

--- a/src/main/res/xml/settings.xml
+++ b/src/main/res/xml/settings.xml
@@ -12,6 +12,7 @@
         android:summary="@string/config_storage_page_hint"
         android:title="@string/config_storage_path"
         android:defaultValue="/phoneypot"
+        android:digits="@string/path_chars"
         />
 
     <Preference


### PR DESCRIPTION
This hopefully will take care of @deviantollam's issues with the filenames.

I don't use straight ISO8601 because resolution is to the _second_, but it's possible _multiple files_ (such
as images) might be saved within a second.  For that reason I've appended milliseconds as well.  This 
actually fixes a separate bug where files are being saved with the same name.

Additionally, to keep weird things like "/.././" etc in directory names, plus spaces or other potential naming
confusions, I've restricted the directory name in the settings to use only alphanumeric + the "/", "_", and
"-" characters.  This can be changed as a string resource for any other characters (such as with
non-qwerty keyboards) or if people want emojis and such in their directory names.  It's really meant to
minimize confusion.  (You can of course put spaces or anything but "/" in directory names in Linux, but
in this case a "/" *IS* legit in case you want to put your directory somewhere...)  Finally on this topic,
the correct thing to do in Android would be to have the user select the directory via an File picker using
the Storage Access Framework-- this could eliminate the requirement for the STORAGE READ/WRITE
permission..

This has not been extensively tested, especially in real-world situations, so I'm hoping @deviantollam
and others can give it a spin.