### PR TITLE
fix blank AppIntro slides

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,17 +143,17 @@ dependencies {
     implementation 'com.wdullaer:materialdatetimepicker:4.1.1'
     implementation 'com.github.guardianproject:signal-cli-android:v0.6.0-android-beta-1'
     implementation 'net.the4thdimension:audio-wife:1.0.3'
-    implementation 'com.github.apl-devs:appintro:master' /* use master until androidx ver is released */
+    implementation 'com.github.AppIntro:AppIntro:v5.1.0'
     implementation 'info.guardianproject.netcipher:netcipher:2.0.0-beta1'
     implementation 'org.nanohttpd:nanohttpd-webserver:2.3.1'
     implementation 'me.angrybyte.picker:picker:1.3.1'
     implementation 'com.github.stfalcon:frescoimageviewer:0.5.0'
     implementation 'com.facebook.fresco:fresco:1.10.0'
-   // implementation 'com.github.derlio.waveform:library:1.0.3@aar'
+    // implementation 'com.github.derlio.waveform:library:1.0.3@aar'
     implementation 'com.github.derlio:audio-waveform:v1.0.1'
     implementation 'org.firezenk:audiowaves:1.1@aar'
     implementation 'com.maxproj.simplewaveform:app:1.0.0'
-    implementation 'com.googlecode.libphonenumber:libphonenumber:8.10.3'
+    implementation 'com.googlecode.libphonenumber:libphonenumber:8.10.4'
     implementation('com.mikepenz:aboutlibraries:6.1.1@aar') {
         transitive = true
     }
@@ -171,11 +171,11 @@ dependencies {
     implementation "android.arch.lifecycle:extensions:1.1.1"
 
     testImplementation "junit:junit:4.12"
-    androidTestImplementation 'androidx.test:runner:1.1.0'
-    androidTestImplementation 'androidx.test:core:1.0.0'
-    androidTestImplementation 'androidx.test:rules:1.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.1.0'
+    androidTestImplementation 'androidx.test:runner:1.1.1'
+    androidTestImplementation 'androidx.test:core:1.1.0'
+    androidTestImplementation 'androidx.test:rules:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.1.1'
     androidTestImplementation "android.arch.persistence.room:testing:1.1.1"
 
     // android-job


### PR DESCRIPTION
- Update to androidx build of AppIntro: fixes blank titles on start/end slides
- update tools while we're at it

**Before:**
 ![screen1](https://user-images.githubusercontent.com/10099969/52359283-d7291c00-29f6-11e9-8afe-c3546245343e.png) 
**After:** 
![screen2](https://user-images.githubusercontent.com/10099969/52359284-d7291c00-29f6-11e9-98b1-6f6c8491e88c.png)
