### PR TITLE
Settings simple layout fix

### DIFF
--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -20,7 +20,6 @@
         <item name="colorAccent">@color/colorAccent</item>
         <item name="android:textColorPrimary">@color/primary_text</item>
         <item name="android:textColorSecondary">@color/secondary_text</item>
-        <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
     </style>
 
     <!-- Style for an Preference Entry -->


### PR DESCRIPTION
Removes the deprecated preferenceTheme attribute which solves the problem:

![1](https://user-images.githubusercontent.com/10099969/52525958-d8fd1480-2c6e-11e9-9d6c-335830a18425.png)     ![2_](https://user-images.githubusercontent.com/10099969/52525967-106bc100-2c6f-11e9-8f36-bc1c9d03fd7a.png)

**As per Preference 1.0.0-rc01 release notes**: 

> - PreferenceThemeOverlay has been updated to the latest material theme. If no custom theme is provided, PreferenceThemeOverlay is used as the default theme.