### PR TITLE
Remove sms support

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.SEND_SMS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <uses-feature

--- a/src/main/java/org/havenapp/main/ListActivity.java
+++ b/src/main/java/org/havenapp/main/ListActivity.java
@@ -369,17 +369,8 @@ public class ListActivity extends AppCompatActivity {
         if (!TextUtils.isEmpty(preferences.getSignalUsername())) {
             SignalSender sender = SignalSender.getInstance(this, preferences.getSignalUsername().trim());
             ArrayList<String> recip = new ArrayList<>();
-            recip.add(preferences.getSmsNumber());
+            recip.add(preferences.getRemotePhoneNumber());
             sender.sendMessage(recip, resourceManager.getString(R.string.signal_test_message), null);
-        }
-        else if (!TextUtils.isEmpty(preferences.getSmsNumber())) {
-
-            SmsManager manager = SmsManager.getDefault();
-
-            StringTokenizer st = new StringTokenizer(preferences.getSmsNumber(),",");
-            while (st.hasMoreTokens())
-                manager.sendTextMessage(st.nextToken(), null, resourceManager.getString(R.string.signal_test_message), null, null);
-
         }
     }
 }

--- a/src/main/java/org/havenapp/main/PreferenceManager.java
+++ b/src/main/java/org/havenapp/main/PreferenceManager.java
@@ -247,10 +247,6 @@ public class PreferenceManager {
     	prefsEditor.commit();
     }
     
-    public boolean getSmsActivation() {
-    	return appSharedPrefs.getBoolean(SMS_ACTIVE, false);
-    }
-    
     public void setSmsNumber(String number) {
 
     	prefsEditor.putString(SMS_NUMBER, number);

--- a/src/main/java/org/havenapp/main/PreferenceManager.java
+++ b/src/main/java/org/havenapp/main/PreferenceManager.java
@@ -100,6 +100,7 @@ public class PreferenceManager {
 
     // keeping the key value same for data migration.
     static final String REMOTE_PHONE_NUMBER = "sms_number";
+    static final String REMOTE_NOTIFICATION_ACTIVE = "remote_notification_active";
 
     private Context context;
 	
@@ -246,6 +247,15 @@ public class PreferenceManager {
     
     public String getMicrophoneSensitivity() {
     	return appSharedPrefs.getString(MICROPHONE_SENSITIVITY, MEDIUM);
+    }
+
+    public void setRemoteNotificationActive(boolean isRemoteNotificationActive) {
+        prefsEditor.putBoolean(REMOTE_NOTIFICATION_ACTIVE, isRemoteNotificationActive);
+        prefsEditor.apply();
+    }
+
+    public boolean isRemoteNotificationActive() {
+        return appSharedPrefs.getBoolean(REMOTE_NOTIFICATION_ACTIVE, false);
     }
 
     public void setRemotePhoneNumber(@NonNull String remotePhoneNumber) {

--- a/src/main/java/org/havenapp/main/PreferenceManager.java
+++ b/src/main/java/org/havenapp/main/PreferenceManager.java
@@ -70,7 +70,6 @@ public class PreferenceManager {
     public static final String REGISTER_SIGNAL = "register_signal";
     public static final String VERIFY_SIGNAL = "verify_signal";
     public static final String VOICE_VERIFY_SIGNAL = "voice_verify_signal";
-    public static final String SEND_SMS = "send_sms";
     private static final String UNLOCK_CODE="unlock_code";
 	
     private static final String ACCESS_TOKEN="access_token";
@@ -99,7 +98,8 @@ public class PreferenceManager {
     public static final String CONFIG_BASE_STORAGE = "config_base_storage";
     private static final String CONFIG_BASE_STORAGE_DEFAULT = "/haven";
 
-    static final String REMOTE_PHONE_NUMBER = "remote_phone_number";
+    // keeping the key value same for data migration.
+    static final String REMOTE_PHONE_NUMBER = "sms_number";
 
     private Context context;
 	

--- a/src/main/java/org/havenapp/main/PreferenceManager.java
+++ b/src/main/java/org/havenapp/main/PreferenceManager.java
@@ -22,12 +22,17 @@ package org.havenapp.main;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
+import android.text.TextUtils;
 
 import org.havenapp.main.sensors.motion.LuminanceMotionDetector;
 
 import java.io.File;
 import java.util.Date;
+import java.util.Objects;
 
+import javax.annotation.Nullable;
+
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
 
@@ -61,8 +66,6 @@ public class PreferenceManager {
     private static final String MICROPHONE_SENSITIVITY="microphone_sensitivity";
     public static final String CONFIG_SOUND = "config_sound";
     public static final String CONFIG_TIME_DELAY = "config_delay_time";
-    public static final String SMS_ACTIVE = "sms_active";
-    public static final String SMS_NUMBER = "sms_number";
     public static final String REGISTER_SIGNAL = "register_signal";
     public static final String VERIFY_SIGNAL = "verify_signal";
     public static final String VOICE_VERIFY_SIGNAL = "voice_verify_signal";
@@ -94,6 +97,8 @@ public class PreferenceManager {
 
     public static final String CONFIG_BASE_STORAGE = "config_base_storage";
     private static final String CONFIG_BASE_STORAGE_DEFAULT = "/haven";
+
+    static final String REMOTE_PHONE_NUMBER = "remote_phone_number";
 
     private Context context;
 	
@@ -241,20 +246,15 @@ public class PreferenceManager {
     public String getMicrophoneSensitivity() {
     	return appSharedPrefs.getString(MICROPHONE_SENSITIVITY, MEDIUM);
     }
-    
-    public void activateSms(boolean active) {
-    	prefsEditor.putBoolean(SMS_ACTIVE, active);
-    	prefsEditor.commit();
-    }
-    
-    public void setSmsNumber(String number) {
 
-    	prefsEditor.putString(SMS_NUMBER, number);
-    	prefsEditor.commit();
+    public void setRemotePhoneNumber(@NonNull String remotePhoneNumber) {
+        prefsEditor.putString(REMOTE_PHONE_NUMBER, remotePhoneNumber.trim());
+        prefsEditor.apply();
     }
-    
-    public String getSmsNumber() {
-    	return appSharedPrefs.getString(SMS_NUMBER, "");
+
+    @NonNull
+    public String getRemotePhoneNumber() {
+        return Objects.requireNonNull(appSharedPrefs.getString(REMOTE_PHONE_NUMBER, ""));
     }
 
     public int getTimerDelay ()

--- a/src/main/java/org/havenapp/main/SettingsFragment.java
+++ b/src/main/java/org/havenapp/main/SettingsFragment.java
@@ -85,9 +85,9 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
 
         }
 
-        findPreference(PreferenceManager.SMS_NUMBER).setOnPreferenceClickListener(preference -> {
-            if (preferences.getSmsNumber().isEmpty()) {
-                ((EditTextPreference) findPreference(PreferenceManager.SMS_NUMBER)).setText(getCountryCode());
+        findPreference(PreferenceManager.REMOTE_PHONE_NUMBER).setOnPreferenceClickListener(preference -> {
+            if (preferences.getRemotePhoneNumber().isEmpty()) {
+                ((EditTextPreference) findPreference(PreferenceManager.REMOTE_PHONE_NUMBER)).setText(getCountryCode());
             }
             return false;
         });
@@ -98,11 +98,12 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
             return false;
         });
 
-        if (checkValidString(preferences.getSmsNumber())) {
-            ((EditTextPreference) findPreference(PreferenceManager.SMS_NUMBER)).setText(preferences.getSmsNumber().trim());
-            findPreference(PreferenceManager.SMS_NUMBER).setSummary(preferences.getSmsNumber().trim());
+        if (checkValidString(preferences.getRemotePhoneNumber())) {
+            ((EditTextPreference) findPreference(PreferenceManager.REMOTE_PHONE_NUMBER))
+                    .setText(preferences.getRemotePhoneNumber());
+            findPreference(PreferenceManager.REMOTE_PHONE_NUMBER).setSummary(preferences.getRemotePhoneNumber());
         } else {
-            findPreference(PreferenceManager.SMS_NUMBER).setSummary(R.string.sms_dialog_summary);
+            findPreference(PreferenceManager.REMOTE_PHONE_NUMBER).setSummary(R.string.sms_dialog_summary);
         }
 
         if (preferences.getRemoteAccessActive()) {
@@ -310,10 +311,6 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
 
                 }
                 break;
-            case PreferenceManager.SMS_ACTIVE:
-
-                setPhoneNumber();
-                break;
             case PreferenceManager.REMOTE_ACCESS_ACTIVE:
                 boolean remoteAccessActive = ((SwitchPreference) findPreference(PreferenceManager.REMOTE_ACCESS_ACTIVE)).isChecked();
                 if (remoteAccessActive) {
@@ -344,12 +341,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
                 activateSignal(preferences.getSignalUsername(), text);
                 break;
             }
-            case PreferenceManager.SMS_NUMBER:
-                boolean smsActive = ((SwitchPreference) findPreference(PreferenceManager.SMS_ACTIVE)).isChecked();
-                if (smsActive && TextUtils.isEmpty(preferences.getSignalUsername())) {
-                    askForPermission(Manifest.permission.SEND_SMS, 6);
-                    askForPermission(Manifest.permission.READ_PHONE_STATE, 6);
-                }
+            case PreferenceManager.REMOTE_PHONE_NUMBER:
                 setPhoneNumber();
                 break;
             case PreferenceManager.NOTIFICATION_TIME:
@@ -448,20 +440,14 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
     }
 
     private void setPhoneNumber() {
-        boolean smsActive = ((SwitchPreference) findPreference(PreferenceManager.SMS_ACTIVE)).isChecked();
-        String phoneNumber = ((EditTextPreference) findPreference(PreferenceManager.SMS_NUMBER)).getText();
-        if (smsActive && checkValidString(phoneNumber)) {
-            preferences.activateSms(true);
-        } else {
-            preferences.activateSms(false);
-        }
+        String phoneNumber = ((EditTextPreference) findPreference(PreferenceManager.REMOTE_PHONE_NUMBER)).getText();
 
         if (checkValidString(phoneNumber) && !getCountryCode().equalsIgnoreCase(phoneNumber)) {
-            preferences.setSmsNumber(phoneNumber.trim());
-            findPreference(PreferenceManager.SMS_NUMBER).setSummary(phoneNumber.trim());
+            preferences.setRemotePhoneNumber(phoneNumber.trim());
+            findPreference(PreferenceManager.REMOTE_PHONE_NUMBER).setSummary(phoneNumber.trim());
         } else if (!getCountryCode().equalsIgnoreCase(phoneNumber)){
-            preferences.setSmsNumber("");
-            findPreference(PreferenceManager.SMS_NUMBER).setSummary(R.string.sms_dialog_message);
+            preferences.setRemotePhoneNumber("");
+            findPreference(PreferenceManager.REMOTE_PHONE_NUMBER).setSummary(R.string.sms_dialog_message);
         }
     }
 

--- a/src/main/java/org/havenapp/main/SettingsFragment.java
+++ b/src/main/java/org/havenapp/main/SettingsFragment.java
@@ -85,10 +85,6 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
 
         }
 
-        if (preferences.getSmsActivation()) {
-            ((SwitchPreference) findPreference(PreferenceManager.SMS_ACTIVE)).setChecked(true);
-        }
-
         findPreference(PreferenceManager.SMS_NUMBER).setOnPreferenceClickListener(preference -> {
             if (preferences.getSmsNumber().isEmpty()) {
                 ((EditTextPreference) findPreference(PreferenceManager.SMS_NUMBER)).setText(getCountryCode());

--- a/src/main/java/org/havenapp/main/SettingsFragment.java
+++ b/src/main/java/org/havenapp/main/SettingsFragment.java
@@ -224,7 +224,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
         String remotePhoneNumber = preferences.getRemotePhoneNumber();
         String signalUsername = preferences.getSignalUsername();
         return !remotePhoneNumber.isEmpty() && !getCountryCode().equalsIgnoreCase(remotePhoneNumber) &&
-                !TextUtils.isEmpty(signalUsername);
+                !TextUtils.isEmpty(signalUsername) && !getCountryCode().equalsIgnoreCase(signalUsername);
     }
 
     /**
@@ -243,6 +243,16 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
         } else {
             activateSignal(signalUsername, null);
         }
+    }
+
+    private void onRemoteNotificationParameterChange() {
+        SwitchPreference switchPreference =
+                (SwitchPreference) findPreference(PreferenceManager.REMOTE_NOTIFICATION_ACTIVE);
+
+        boolean remoteNotificationActive = canSendRemoteNotification();
+        preferences.setRemoteNotificationActive(remoteNotificationActive);
+
+        switchPreference.setChecked(remoteNotificationActive);
     }
 
     @Override
@@ -391,17 +401,17 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
                     preferences.setSignalUsername("");
                     findPreference(PreferenceManager.REGISTER_SIGNAL).setSummary(R.string.register_signal_desc);
                 }
+                onRemoteNotificationParameterChange();
                 break;
             case PreferenceManager.VERIFY_SIGNAL: {
                 String text = ((EditTextPreference) findPreference(PreferenceManager.VERIFY_SIGNAL)).getText();
                 activateSignal(preferences.getSignalUsername(), text);
+                onRemoteNotificationParameterChange();
                 break;
             }
-            case PreferenceManager.REMOTE_NOTIFICATION_ACTIVE:
-                // todo not - needed: Test this out.
-                break;
             case PreferenceManager.REMOTE_PHONE_NUMBER:
                 setPhoneNumber();
+                onRemoteNotificationParameterChange();
                 break;
             case PreferenceManager.NOTIFICATION_TIME:
                 try

--- a/src/main/java/org/havenapp/main/service/MonitorService.java
+++ b/src/main/java/org/havenapp/main/service/MonitorService.java
@@ -367,13 +367,6 @@ public class MonitorService extends Service {
                 }
 
                 sender.sendMessage(recips, alertMessage.toString(), attachment);
-            } else if (mPrefs.getSmsActivation()) {
-                SmsManager manager = SmsManager.getDefault();
-
-                StringTokenizer st = new StringTokenizer(mPrefs.getSmsNumber(), ",");
-                while (st.hasMoreTokens())
-                    manager.sendTextMessage(st.nextToken(), null, alertMessage.toString(), null, null);
-
             }
         }
 

--- a/src/main/java/org/havenapp/main/service/MonitorService.java
+++ b/src/main/java/org/havenapp/main/service/MonitorService.java
@@ -352,7 +352,7 @@ public class MonitorService extends Service {
 
                 SignalSender sender = SignalSender.getInstance(this, mPrefs.getSignalUsername());
                 ArrayList<String> recips = new ArrayList<>();
-                StringTokenizer st = new StringTokenizer(mPrefs.getSmsNumber(), ",");
+                StringTokenizer st = new StringTokenizer(mPrefs.getRemotePhoneNumber(), ",");
                 while (st.hasMoreTokens())
                     recips.add(st.nextToken());
 

--- a/src/main/java/org/havenapp/main/service/SignalSender.java
+++ b/src/main/java/org/havenapp/main/service/SignalSender.java
@@ -126,16 +126,8 @@ public class SignalSender {
         if (!TextUtils.isEmpty(mUsername)) {
             getInstance(mContext, mUsername.trim());
             ArrayList<String> recipient = new ArrayList<>();
-            recipient.add(preferences.getSmsNumber());
+            recipient.add(preferences.getRemotePhoneNumber());
             sendMessage(recipient, emojiString,null);
-        }
-        else if (!TextUtils.isEmpty(preferences.getSmsNumber())) {
-
-            SmsManager manager = SmsManager.getDefault();
-
-            StringTokenizer st = new StringTokenizer(preferences.getSmsNumber(),",");
-            while (st.hasMoreTokens())
-                manager.sendTextMessage(st.nextToken(), null, emojiString, null, null);
         }
     }
 

--- a/src/main/java/org/havenapp/main/ui/CustomSlideNotify.java
+++ b/src/main/java/org/havenapp/main/ui/CustomSlideNotify.java
@@ -7,12 +7,14 @@ package org.havenapp.main.ui;
 
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
 
+import org.havenapp.main.PreferenceManager;
 import org.havenapp.main.R;
 
 import androidx.annotation.NonNull;
@@ -62,6 +64,9 @@ public class CustomSlideNotify extends Fragment {
             @Override
             public void onClick(View v) { }
         });
+        PreferenceManager pm = new PreferenceManager(getActivity());
+        if (!TextUtils.isEmpty(pm.getRemotePhoneNumber()))
+            mEditNumber.setText(pm.getRemotePhoneNumber());
 
         // todo describe why we are asking this maybe
 

--- a/src/main/java/org/havenapp/main/ui/CustomSlideNotify.java
+++ b/src/main/java/org/havenapp/main/ui/CustomSlideNotify.java
@@ -5,19 +5,17 @@ package org.havenapp.main.ui;
  */
 
 
-import android.Manifest;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
-import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
 
-import org.havenapp.main.PreferenceManager;
 import org.havenapp.main.R;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
@@ -62,15 +60,10 @@ public class CustomSlideNotify extends Fragment {
         mEditNumber = view.findViewById(R.id.editNumber);
         mEditNumber.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View v) {
-                askForPermission(Manifest.permission.SEND_SMS,6);
-                askForPermission(Manifest.permission.READ_PHONE_STATE,6);
-
-            }
+            public void onClick(View v) { }
         });
-        PreferenceManager pm = new PreferenceManager(getActivity());
-        if (!TextUtils.isEmpty(pm.getSmsNumber()))
-            mEditNumber.setText(pm.getSmsNumber());
+
+        // todo describe why we are asking this maybe
 
         Button button = view.findViewById(R.id.btnSaveNumber);
         button.setOnClickListener(mListener);
@@ -78,9 +71,10 @@ public class CustomSlideNotify extends Fragment {
 
     }
 
+    @NonNull
     public String getPhoneNumber ()
     {
-        return mEditNumber.getText().toString();
+        return mEditNumber.getText() != null ? mEditNumber.getText().toString() : "";
     }
 
     private void askForPermission(String permission, Integer requestCode) {

--- a/src/main/java/org/havenapp/main/ui/PPAppIntro.java
+++ b/src/main/java/org/havenapp/main/ui/PPAppIntro.java
@@ -59,8 +59,7 @@ public class PPAppIntro extends AppIntro {
             @Override
             public void onClick(View v) {
                 PreferenceManager pm = new PreferenceManager(PPAppIntro.this);
-                pm.activateSms(true);
-                pm.setSmsNumber(cs4.getPhoneNumber());
+                pm.setRemotePhoneNumber(cs4.getPhoneNumber());
                 Toast.makeText(PPAppIntro.this, R.string.phone_saved,Toast.LENGTH_SHORT).show();
                 getPager().setCurrentItem(getPager().getCurrentItem()+1);
             }

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -17,7 +17,7 @@
     	Verzögerungszeit setzen
     </string>
 
-    <string name="sms_label">"Bei Alarm SMS oder Signal Nachricht senden "</string>
+    <string name="remote_notification_label">"Bei Alarm SMS oder Signal Nachricht senden "</string>
 
     <string name="sms_hint">+4917712345678</string>
 

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -17,7 +17,7 @@
         Temporizador
     </string>
 
-    <string name="sms_label">
+    <string name="remote_notification_label">
         Enviar SMS o mensaje de alerta por Signal
     </string>
 

--- a/src/main/res/values-fr/strings.xml
+++ b/src/main/res/values-fr/strings.xml
@@ -17,7 +17,7 @@
 		Déterminer un délai
 	</string>
 
-    <string name="sms_label">
+    <string name="remote_notification_label">
 		Envoyer SMS ou des alertes par message Signal
 	</string>
 

--- a/src/main/res/values-it/strings.xml
+++ b/src/main/res/values-it/strings.xml
@@ -19,7 +19,7 @@
     	Imposta il timer di avvio
     </string>
 
-    <string name="sms_label">
+    <string name="remote_notification_label">
     	Invia SMS o messaggi via Signal
     </string>
 

--- a/src/main/res/values-ja/strings.xml
+++ b/src/main/res/values-ja/strings.xml
@@ -17,7 +17,7 @@
     	開始遅延時間
     </string>
 
-    <string name="sms_label">
+    <string name="remote_notification_label">
     	ショートメールで警告を送信
     </string>
 

--- a/src/main/res/values-pt/strings.xml
+++ b/src/main/res/values-pt/strings.xml
@@ -17,7 +17,7 @@
     	Definir tempo de atraso
     </string>
 
-    <string name="sms_label">
+    <string name="remote_notification_label">
     	Enviar mensagens de alerta de SMS ou Signal
     </string>
 

--- a/src/main/res/values-ru/strings.xml
+++ b/src/main/res/values-ru/strings.xml
@@ -17,7 +17,7 @@
     	Установка времени задержки
     </string>
 
-    <string name="sms_label">
+    <string name="remote_notification_label">
     	Оповещать по SMS или через Signal
     </string>
 

--- a/src/main/res/values-sr/strings.xml
+++ b/src/main/res/values-sr/strings.xml
@@ -17,7 +17,7 @@
     	Vreme odlaganja
     </string>
 
-    <string name="sms_label">
+    <string name="remote_notification_label">
     	Šalji SMS ili Signal upozorenja
     </string>
 

--- a/src/main/res/values-tr/strings.xml
+++ b/src/main/res/values-tr/strings.xml
@@ -17,7 +17,7 @@
     	Bekleme Süresi
     </string>
 
-    <string name="sms_label">
+    <string name="remote_notification_label">
     	SMS veya Signal ile uyarı mesajı gönder
     </string>
 

--- a/src/main/res/values-zh/strings.xml
+++ b/src/main/res/values-zh/strings.xml
@@ -19,7 +19,7 @@
     	设置延时
     </string>
 
-    <string name="sms_label">
+    <string name="remote_notification_label">
     	使用发送短信或 Signal 发送警告
     </string>
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -19,8 +19,8 @@
     	Set Delay Time
     </string>
 
-    <string name="sms_label">
-    	Send SMS or Signal message alerts
+    <string name="remote_notification_label">
+    	Send Signal message alerts
     </string>
 
     <string name="sms_hint">

--- a/src/main/res/xml/settings.xml
+++ b/src/main/res/xml/settings.xml
@@ -57,9 +57,9 @@
     <PreferenceCategory android:title="@string/label_notifications">
 
         <SwitchPreference
-            android:defaultValue="true"
-            android:key="sms_active"
-            android:title="@string/sms_label" />
+            android:defaultValue="false"
+            android:key="remote_notification_active"
+            android:title="@string/remote_notification_label" />
 
         <EditTextPreference
             style="@style/AppPreference.DialogPreferenceSave"

--- a/src/main/res/xml/settings.xml
+++ b/src/main/res/xml/settings.xml
@@ -66,7 +66,7 @@
             android:dialogLayout="@layout/pref_dialog_edit_text_hint"
             android:dialogMessage="@string/sms_dialog_message"
             android:inputType="phone"
-            android:key="remote_phone_number"
+            android:key="sms_number"
             android:summary="@string/sms_dialog_summary"
             android:title="@string/phone_number" />
 

--- a/src/main/res/xml/settings.xml
+++ b/src/main/res/xml/settings.xml
@@ -66,7 +66,7 @@
             android:dialogLayout="@layout/pref_dialog_edit_text_hint"
             android:dialogMessage="@string/sms_dialog_message"
             android:inputType="phone"
-            android:key="sms_number"
+            android:key="remote_phone_number"
             android:summary="@string/sms_dialog_summary"
             android:title="@string/phone_number" />
 


### PR DESCRIPTION
Aims to solve #364 

Changes

- Removed `SEND_SMS` permission -> removed remote SMS notification feature.
- On Settings the Switch for enabling SMS and Signal notifications now only enables remote notification through Signal.
- on enabling the Switch we collect data required for remote notification ( a remote phone number, a verified signal phone number)
- the String for the Switch name has been edited, we need to update translations for the same.

Some thoughts:

- During on-boarding we may need to add a note to complete the Signal integration since having a remote number will not enable notification. IMO the Signal integration process is not very intuitive and can be further streamlined. 