### PR TITLE
Power event state improvements

### DIFF
--- a/src/main/java/org/havenapp/main/sensors/PowerConnectionReceiver.java
+++ b/src/main/java/org/havenapp/main/sensors/PowerConnectionReceiver.java
@@ -3,6 +3,8 @@ package org.havenapp.main.sensors;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.BatteryManager;
 
 import org.havenapp.main.R;
 import org.havenapp.main.model.EventTrigger;
@@ -26,7 +28,14 @@ public class PowerConnectionReceiver extends BroadcastReceiver {
 
         // explicitly check the intent action
         // avoids lint issue UnsafeProtectedBroadcastReceiver
-        boolean isCharging;
+        int status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
+        boolean isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING ||
+                status == BatteryManager.BATTERY_STATUS_FULL;
+
+        int chargePlug = intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1);
+        boolean usbCharge = chargePlug == BatteryManager.BATTERY_PLUGGED_USB;
+        boolean acCharge = chargePlug == BatteryManager.BATTERY_PLUGGED_AC;
+
         if(intent.getAction() == null) return;
         switch(intent.getAction()){
             case Intent.ACTION_POWER_CONNECTED:
@@ -43,5 +52,17 @@ public class PowerConnectionReceiver extends BroadcastReceiver {
                 && MonitorService.getInstance().isRunning()) {
             MonitorService.getInstance().alert(EventTrigger.POWER, context.getString(R.string.status_charging) + isCharging );
         }
+    }
+
+    //Ref: https://developer.android.com/training/monitoring-device-state/battery-monitoring.html
+
+    private void getBatteryStatus(Context context) {
+        IntentFilter ifilter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
+        Intent batteryStatus = context.registerReceiver(null, ifilter);
+
+        // How are we charging?
+        int chargePlug = batteryStatus.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1);
+        boolean usbCharge = chargePlug == BatteryManager.BATTERY_PLUGGED_USB;
+        boolean acCharge = chargePlug == BatteryManager.BATTERY_PLUGGED_AC;
     }
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -80,11 +80,9 @@
     <string name="action_cancel">Deactivate</string>
     <string name="status_on">ACTIVE</string>
     <string name="power_source_status_usb">USB Charging</string>
-    <string name="power_source_status_wireless">Wireless</string>
+    <string name="power_source_status_wireless">Wireless Charging</string>
     <string name="power_source_status_ac">AC Charging</string>
     <string name="power_source_status">STATE:</string>
-    <string name="status_charging">Charging</string>
-    <string name="power_connected">Connected</string>
     <string name="power_disconnected">Disconnected</string>
     <string name="you_will_receive_a_text_when_the_app_hears_or_sees_something">You will receive a text when the app hears or sees something</string>
     <string name="know_immediately_when_haven_detects_something">Know immediately when Haven detects something</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -79,8 +79,13 @@
 
     <string name="action_cancel">Deactivate</string>
     <string name="status_on">ACTIVE</string>
-    <string name="status_charging">Charging:</string>
-    <string name="power_source">Power Source: </string>
+    <string name="power_source_status_usb">USB Charging</string>
+    <string name="power_source_status_wireless">Wireless</string>
+    <string name="power_source_status_ac">AC Charging</string>
+    <string name="power_source_status">STATE:</string>
+    <string name="status_charging">Charging</string>
+    <string name="power_connected">Connected</string>
+    <string name="power_disconnected">Disconnected</string>
     <string name="you_will_receive_a_text_when_the_app_hears_or_sees_something">You will receive a text when the app hears or sees something</string>
     <string name="know_immediately_when_haven_detects_something">Know immediately when Haven detects something</string>
     <string name="phone_saved">Phone number saved!</string>
@@ -89,6 +94,7 @@
     <string name="data_light">LIGHT</string>
     <string name="data_pressure">PRESSURE</string>
     <string name="data_power">POWER</string>
+    <string name="data_battery">BATTERY</string>
     <string name="share_event_action">Share event...</string>
     <string name="signal_test_message">This is a test message from Haven</string>
     <string name="send_test_message">Send Test Message</string>
@@ -108,7 +114,7 @@
     <string name="sensor_accel">Motion (Accelerometer)</string>
     <string name="sensor_camera">Motion (Camera)</string>
     <string name="sensor_sound">Microphone</string>
-    <string name="sensor_power">USB Power</string>
+    <string name="sensor_power">Power</string>
     <string name="sensor_bump">Bump (Accelerometer)</string>
     <string name="sensor_camera_video">Motion (Video)</string>
     <string name="sensor_heartbeat">Heartbeat</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -80,6 +80,7 @@
     <string name="action_cancel">Deactivate</string>
     <string name="status_on">ACTIVE</string>
     <string name="status_charging">Charging:</string>
+    <string name="power_source">Power Source: </string>
     <string name="you_will_receive_a_text_when_the_app_hears_or_sees_something">You will receive a text when the app hears or sees something</string>
     <string name="know_immediately_when_haven_detects_something">Know immediately when Haven detects something</string>
     <string name="phone_saved">Phone number saved!</string>


### PR DESCRIPTION
Aims to address #325 
- Remove hardcoded 'USB' from event
- Return Disconnected, USB, AC & Wireless states on change
- Add battery percentage

_Sample output when unplugged & quickly reconnected:_

**Power**
Feb 12, 2019 2:33:30 PM
POWER: 100%
STATE: Disconnected

**Power**
Feb 12, 2019 2:33:32 PM
POWER: 100%
STATE: USB Charging

Notes: faulty cable/connection may deliver odd power events as noted in #325. Testing concluded that voltage drops from a furnace, etc. can trigger a power event. Adding a delay would only add an attack vector (and false positives have been minimal). That said, testing and comments appreciated here.

I am going to look into making alerts configurable, with sensitivity options as suggested in #324 but for now I think this makes sense.