### PR TITLE
Set restored fragment to mFragment when Activity is restored

### DIFF
--- a/src/main/java/org/havenapp/main/SettingsActivity.java
+++ b/src/main/java/org/havenapp/main/SettingsActivity.java
@@ -40,6 +40,8 @@ public class SettingsActivity extends AppCompatActivity {
             getSupportFragmentManager().beginTransaction()
                     .add(R.id.settings_fragment, mFragment)
                     .commit();
+        } else {
+            mFragment = (SettingsFragment) getSupportFragmentManager().findFragmentById(R.id.settings_fragment);
         }
 
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);


### PR DESCRIPTION
Pressing back on `SettingsActivity` when it was restored gave this crash

```
java.lang.NullPointerException: Attempt to invoke virtual method 'void org.havenapp.main.SettingsFragment.save()' on a null object reference
 at org.havenapp.main.SettingsActivity.onBackPressed(SettingsActivity.java:60)
 at android.app.Activity.onKeyUp(Activity.java:2805)
 at android.view.KeyEvent.dispatch(KeyEvent.java:2701)
 at androidx.core.view.KeyEventDispatcher.activitySuperDispatchKeyEventPre28(KeyEventDispatcher.java:137)
 at androidx.core.view.KeyEventDispatcher.dispatchKeyEvent(KeyEventDispatcher.java:87)
 at androidx.core.app.ComponentActivity.dispatchKeyEvent(ComponentActivity.java:126)
 at androidx.appcompat.app.AppCompatActivity.dispatchKeyEvent(AppCompatActivity.java:535)
 at androidx.appcompat.view.WindowCallbackWrapper.dispatchKeyEvent(WindowCallbackWrapper.java:59)
 at androidx.appcompat.app.AppCompatDelegateImpl$AppCompatWindowCallback.dispatchKeyEvent(AppCompatDelegateImpl.java:2533)
 at com.android.internal.policy.DecorView.dispatchKeyEvent(DecorView.java:320)
 at android.view.ViewRootImpl$ViewPostImeInputStage.processKeyEvent(ViewRootImpl.java:4384)
 at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(ViewRootImpl.java:4355)
 at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:3899)
 at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:3952)
 at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:3918)
 at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:4045)
 at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:3926)
 at android.view.ViewRootImpl$AsyncInputStage.apply(ViewRootImpl.java:4102)
 at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:3899)
 at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:3952)
 at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:3918)
 at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:3926)
 at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:3899)
 at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:3952)
 at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:3918)
 at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:4078)
 at android.view.ViewRootImpl$ImeInputStage.onFinishedInputEvent(ViewRootImpl.java:4246)
 at android.view.inputmethod.InputMethodManager$PendingEvent.run(InputMethodManager.java:2397)
 at android.view.inputmethod.InputMethodManager.invokeFinishedInputEventCallback(InputMethodManager.java:1993)
 at android.view.inputmethod.InputMethodManager.finishedInputEvent(InputMethodManager.java:1984)
 at android.view.inputmethod.InputMethodManager$ImeInputEventSender.onInputEventFinished(InputMethodManager.java:2374)
 at android.view.InputEventSender.dispatchInputEventFinished(InputEventSender.java:141)
 at android.os.MessageQueue.nativePollOnce(Native Method)
 at android.os.MessageQueue.next(MessageQueue.java:329)
 at android.os.Looper.loop(Looper.java:142)
 at android.app.ActivityThread.main(ActivityThread.java:6375)
 at java.lang.reflect.Method.invoke(Native Method)
 at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:912)
 at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:802)
```

This is because we do not save the restored fragment instance in `mFragment` when `savedInstanceState` is non-null.

This PR aims to resolve that.