### PR TITLE
Fix crash on switching camera

### DIFF
--- a/src/main/java/org/havenapp/main/ui/CameraConfigureActivity.java
+++ b/src/main/java/org/havenapp/main/ui/CameraConfigureActivity.java
@@ -101,7 +101,7 @@ public class CameraConfigureActivity extends AppCompatActivity {
         else if (camera.equals(PreferenceManager.BACK))
             mPrefManager.setCamera(PreferenceManager.FRONT);
 
-        ((CameraFragment) getSupportFragmentManager().findFragmentById(R.id.fragment_camera)).updateCamera();
+        mFragment.updateCamera();
         setResult(RESULT_OK);
     }
 


### PR DESCRIPTION
_Testing/review always appreciated for these one-line fixes:_
- Resolves crash when camera facing is unexpected (-1 instead of the expected 0/1)
- Use current fragment instead of searching for a null support fragment
- Resolves Settings & Monitor activity entry points
