### PR TITLE
Remove reserved icon spacing from Settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,6 +133,10 @@ android {
     }
 }
 
+configurations {
+    all*.exclude group: 'com.google.guava', module: 'listenablefuture'
+}
+
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.cardview:cardview:1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'androidx.preference:preference:1.0.0'
+    implementation 'androidx.preference:preference:1.1.0-alpha03'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.annotation:annotation:1.0.1'
     implementation 'com.google.android.material:material:1.0.0'

--- a/src/main/res/xml/settings.xml
+++ b/src/main/res/xml/settings.xml
@@ -1,11 +1,14 @@
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="config_delay_time"
         android:title="@string/timer_delay_label" />
 
     <EditTextPreference
+        app:iconSpaceReserved="false"
         android:dialogLayout="@layout/pref_dialog_edit_text"
         android:dialogMessage="@string/config_storage_page_hint"
         android:key="config_base_storage"
@@ -16,24 +19,32 @@
         />
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="config_battery_optimizations"
         android:title="@string/disable_battery_opt_title"
         android:summary="@string/disable_battery_opt_summary"/>
 
-    <PreferenceCategory android:title="@string/video_settings">
+    <PreferenceCategory
+        app:iconSpaceReserved="false"
+        android:title="@string/video_settings">
         <Preference
+            app:iconSpaceReserved="false"
             android:key="config_video_length"
             android:title="@string/config_video_length_label" />
 
         <SwitchPreference
+            app:iconSpaceReserved="false"
             android:defaultValue="false"
             android:key="@string/video_active_preference_key"
             android:title="@string/video_monitoring"/>
     </PreferenceCategory>
 
-    <PreferenceCategory android:title="@string/sensors">
+    <PreferenceCategory
+        app:iconSpaceReserved="false"
+        android:title="@string/sensors">
 
         <ListPreference
+            app:iconSpaceReserved="false"
             android:entries="@array/camera"
             android:entryValues="@array/camera_alias"
             android:key="camera"
@@ -41,28 +52,34 @@
             android:title="@string/camera_prompt" />
 
         <Preference
+            app:iconSpaceReserved="false"
             android:key="camera_sensitivity"
             android:title="@string/camera_sensitivity" />
 
         <Preference
+            app:iconSpaceReserved="false"
             android:key="config_sound"
             android:title="@string/microphone_sensitivity" />
 
         <Preference
+            app:iconSpaceReserved="false"
             android:key="config_movement"
             android:title="@string/accelerometer_prompt" />
 
-
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/label_notifications">
+
+    <PreferenceCategory
+        app:iconSpaceReserved="false"
+        android:title="@string/label_notifications">
 
         <SwitchPreference
+            app:iconSpaceReserved="false"
             android:defaultValue="true"
             android:key="sms_active"
             android:title="@string/sms_label" />
 
         <EditTextPreference
-            style="@style/AppPreference.DialogPreferenceSave"
+            app:iconSpaceReserved="false"
             android:dialogLayout="@layout/pref_dialog_edit_text_hint"
             android:dialogMessage="@string/sms_dialog_message"
             android:inputType="phone"
@@ -71,7 +88,7 @@
             android:title="@string/phone_number" />
 
         <EditTextPreference
-            style="@style/AppPreference.DialogPreferenceRegister"
+            app:iconSpaceReserved="false"
             android:dialogLayout="@layout/pref_dialog_edit_text_hint_signal"
             android:dialogMessage="@string/register_signal_desc"
             android:inputType="phone"
@@ -80,7 +97,7 @@
             android:title="@string/signal_number" />
 
         <EditTextPreference
-            style="@style/AppPreference.DialogPreferenceVerify"
+            app:iconSpaceReserved="false"
             android:dialogLayout="@layout/pref_dialog_edit_text"
             android:dialogMessage="@string/enter_verification"
             android:inputType="number"
@@ -89,25 +106,27 @@
             android:title="@string/verify_signal" />
 
         <EditTextPreference
-            style="@style/AppPreference.DialogPreferenceSave"
+            app:iconSpaceReserved="false"
             android:dialogLayout="@layout/pref_dialog_edit_text"
             android:dialogMessage="@string/notification_time_dialog"
             android:inputType="number"
             android:key="notification_time"
             android:summary="@string/notification_time_summary"
-            android:title="@string/notification_time"
-            />
+            android:title="@string/notification_time" />
 
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/hearbeat_monitor">
+    <PreferenceCategory
+        app:iconSpaceReserved="false"
+        android:title="@string/hearbeat_monitor">
 
         <SwitchPreference
+            app:iconSpaceReserved="false"
             android:defaultValue="false"
             android:key="heartbeat_monitor_active"
             android:title="@string/hearbeat_monitor_enable" />
 
         <EditTextPreference
-            style="@style/AppPreference.DialogPreferenceSave"
+            app:iconSpaceReserved="false"
             android:dialogLayout="@layout/pref_dialog_edit_text"
             android:dialogMessage="@string/heartbeat_time_dialog"
             android:inputType="number"
@@ -116,15 +135,19 @@
             android:title="@string/hearbeat_monitor_summary"/>
 
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/remote_access">
+    <PreferenceCategory
+        app:iconSpaceReserved="false"
+        android:title="@string/remote_access">
 
         <SwitchPreference
+            app:iconSpaceReserved="false"
             android:defaultValue="false"
             android:key="remote_access_active"
             android:summary="@string/remote_access_label"
             android:title="@string/remote_access" />
 
         <EditTextPreference
+            app:iconSpaceReserved="false"
             android:dialogLayout="@layout/pref_dialog_edit_text"
             android:dialogMessage="@string/remote_access_hint"
             android:key="remote_access_onion"
@@ -132,6 +155,7 @@
             android:title="@string/service_address" />
 
         <EditTextPreference
+            app:iconSpaceReserved="false"
             android:dialogLayout="@layout/pref_dialog_edit_password"
             android:dialogMessage="@string/remote_access_credential_hint"
             android:inputType="textPassword"


### PR DESCRIPTION
Updated:
- `preference:1.1.0-alpha03`

Settings layout changes:
- androidx & v28 library compatibility fixes while in alpha
- remove unsupported "style" attributes
- fix settings alignment using `app:iconSpaceReserved="false"` 

*A loop fixed all but PreferenceCategory elements, thus the addition to each of the Preferences.  

_Ref bug https://issuetracker.google.com/issues/116154359_
