### PR TITLE
 Force clean deleted logs from disk & Bug Fix

### DIFF
--- a/src/main/java/org/havenapp/main/ListActivity.java
+++ b/src/main/java/org/havenapp/main/ListActivity.java
@@ -321,6 +321,9 @@ public class ListActivity extends AppCompatActivity {
             case R.id.action_test_notification:
                 testNotifications();
                 break;
+            case R.id.action_run_cleanup_job:
+                runCleanUpJob();
+                break;
         }
         return true;
     }
@@ -335,6 +338,10 @@ public class ListActivity extends AppCompatActivity {
     {
         final List<Event> removedEvents = new ArrayList<>(events);
         new EventDeleteAllAsync(() -> onAllEventsRemoved(removedEvents)).execute(removedEvents);
+    }
+
+    private void runCleanUpJob() {
+        RemoveDeletedFilesJob.Companion.runNow();
     }
 
     private void onAllEventsRemoved(List<Event> removedEvents) {

--- a/src/main/java/org/havenapp/main/service/RemoveDeletedFilesJob.kt
+++ b/src/main/java/org/havenapp/main/service/RemoveDeletedFilesJob.kt
@@ -28,6 +28,13 @@ class RemoveDeletedFilesJob: Job() {
                     .build()
                     .schedule()
         }
+
+        fun runNow(): Int {
+            return JobRequest.Builder(SERVICE_TAG)
+                    .startNow()
+                    .build()
+                    .schedule()
+        }
     }
 
     override fun onRunJob(params: Params): Result {

--- a/src/main/java/org/havenapp/main/service/RemoveDeletedFilesJob.kt
+++ b/src/main/java/org/havenapp/main/service/RemoveDeletedFilesJob.kt
@@ -117,7 +117,9 @@ class RemoveDeletedFilesJob: Job() {
         if (!storageDir.exists() || !storageDir.isDirectory)
             return
 
-        storageDir.listFiles() ?: currentFileList.addAll(storageDir.listFiles())
+        storageDir.listFiles()?.let {
+            currentFileList.addAll(it)
+        }
 
         val subDir = storageDir.list { dir, name -> File(dir, name).isDirectory }
         subDir.filter { it != null }.forEach { getAllFileInStorageDir(File(storageDir, it), currentFileList) }

--- a/src/main/res/menu/menu_main.xml
+++ b/src/main/res/menu/menu_main.xml
@@ -24,6 +24,13 @@
         android:orderInCategory="100"
         android:title="@string/menu_licenses"
         app:showAsAction="never" />
+
+    <item
+        android:id="@+id/action_run_cleanup_job"
+        android:title="@string/run_disk_cleanup"
+        android:orderInCategory="2"
+        app:showAsAction="never"/>
+
     <item
         android:id="@+id/action_remove_all_events"
         android:title="@string/remove_all_logs"

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -181,5 +181,6 @@
 
     <string name="status_recording_video">Recording...</string>
     <string name="status_light">LIGHT DETECTED</string>
+    <string name="run_disk_cleanup">Clean deleted logs from disk</string>
 
 </resources>


### PR DESCRIPTION
- clean up job may not run periodically on devices due to factors mentioned in https://github.com/evernote/android-job/wiki/FAQ#what-happens-with-jobs-after-the-app-was-forced-killed This option hence powers the user to run the job at the exact moment
- Fix wrong null check.