### PR TITLE
Bug Fix and Recycler View optimisation

### DIFF
--- a/src/main/java/org/havenapp/main/ui/EventActivity.java
+++ b/src/main/java/org/havenapp/main/ui/EventActivity.java
@@ -127,7 +127,7 @@ public class EventActivity extends AppCompatActivity implements EventTriggerAdap
      */
     private void onEventTriggerListFetched(@NonNull List<EventTrigger> eventTriggerList) {
         this.eventTriggerList = eventTriggerList;
-        setEventTriggerImagePaths(eventTriggerList);
+        setEventTriggerImagePaths();
         mAdapter.setEventTriggers(eventTriggerList);
     }
 
@@ -241,8 +241,8 @@ public class EventActivity extends AppCompatActivity implements EventTriggerAdap
     }
 
     @Override
-    public void onImageClick(@NotNull EventTrigger eventTrigger) {
-        int startPosition = 0;
+    public void onImageClick(@NotNull EventTrigger eventTrigger, int position) {
+        int startPosition = getPositionOfImagePath(position);
 
         ShareOverlayView overlayView = new ShareOverlayView(this);
         ImageViewer viewer = new ImageViewer.Builder<>(this, eventTriggerImagePaths)
@@ -265,7 +265,7 @@ public class EventActivity extends AppCompatActivity implements EventTriggerAdap
         startActivity(shareIntent);
     }
 
-    private void setEventTriggerImagePaths(List<EventTrigger> eventTriggerList) {
+    private void setEventTriggerImagePaths() {
         this.eventTriggerImagePaths = new ArrayList<>();
         for (EventTrigger trigger : eventTriggerList)
         {
@@ -275,5 +275,16 @@ public class EventActivity extends AppCompatActivity implements EventTriggerAdap
                eventTriggerImagePaths.add(Uri.fromFile(new File(trigger.getPath())));
             }
         }
+    }
+
+    private int getPositionOfImagePath(int position) {
+        int pos = -1;
+        for (int i = 0; i <= position; i++) {
+            if (eventTriggerList.get(i).getType() == EventTrigger.CAMERA &&
+                    (!TextUtils.isEmpty(eventTriggerList.get(i).getPath()))) {
+                pos++;
+            }
+        }
+        return pos;
     }
 }

--- a/src/main/java/org/havenapp/main/ui/EventActivity.java
+++ b/src/main/java/org/havenapp/main/ui/EventActivity.java
@@ -23,6 +23,7 @@ import org.havenapp.main.model.Event;
 import org.havenapp.main.model.EventTrigger;
 import org.havenapp.main.resources.IResourceManager;
 import org.havenapp.main.resources.ResourceManager;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
@@ -228,19 +229,19 @@ public class EventActivity extends AppCompatActivity implements EventTriggerAdap
     }
 
     @Override
-    public void onVideoClick(EventTrigger eventTrigger) {
+    public void onVideoClick(@NotNull EventTrigger eventTrigger) {
         Intent intent = new Intent(this, VideoPlayerActivity.class);
         intent.setData(Uri.fromFile(new File(eventTrigger.getPath())));
         startActivity(intent);
     }
 
     @Override
-    public void onVideoLongClick(EventTrigger eventTrigger) {
+    public void onVideoLongClick(@NotNull EventTrigger eventTrigger) {
         shareMedia(eventTrigger);
     }
 
     @Override
-    public void onImageClick(EventTrigger eventTrigger) {
+    public void onImageClick(@NotNull EventTrigger eventTrigger) {
         int startPosition = 0;
 
         ShareOverlayView overlayView = new ShareOverlayView(this);
@@ -252,7 +253,7 @@ public class EventActivity extends AppCompatActivity implements EventTriggerAdap
     }
 
     @Override
-    public void onImageLongClick(EventTrigger eventTrigger) {
+    public void onImageLongClick(@NotNull EventTrigger eventTrigger) {
         shareMedia(eventTrigger);
     }
 

--- a/src/main/java/org/havenapp/main/ui/EventAdapter.java
+++ b/src/main/java/org/havenapp/main/ui/EventAdapter.java
@@ -47,6 +47,7 @@ public class EventAdapter extends RecyclerView.Adapter<EventAdapter.EventVH> {
         String desc = event.getEventTriggerCount() + " " +
                 resourceManager.getString(R.string.detection_events);
 
+        holder.index.setText("#" + (position + 1));
         holder.title.setText(title);
         holder.note.setText(desc);
 
@@ -58,11 +59,12 @@ public class EventAdapter extends RecyclerView.Adapter<EventAdapter.EventVH> {
     }
 
     class EventVH extends RecyclerView.ViewHolder implements View.OnClickListener {
-        TextView title, note;
+        TextView index, title, note;
 
         EventVH(View itemView) {
             super(itemView);
 
+            index = itemView.findViewById(R.id.index_number);
            title = itemView.findViewById(R.id.event_item_title);
             note = itemView.findViewById(R.id.event_item_desc);
 

--- a/src/main/java/org/havenapp/main/ui/EventAdapter.java
+++ b/src/main/java/org/havenapp/main/ui/EventAdapter.java
@@ -65,7 +65,7 @@ public class EventAdapter extends RecyclerView.Adapter<EventAdapter.EventVH> {
             super(itemView);
 
             index = itemView.findViewById(R.id.index_number);
-           title = itemView.findViewById(R.id.event_item_title);
+           title = itemView.findViewById(R.id.title);
             note = itemView.findViewById(R.id.event_item_desc);
 
             itemView.setOnClickListener(this);

--- a/src/main/java/org/havenapp/main/ui/EventTriggerAdapter.java
+++ b/src/main/java/org/havenapp/main/ui/EventTriggerAdapter.java
@@ -1,25 +1,17 @@
 package org.havenapp.main.ui;
 
 import android.content.Context;
-import android.graphics.drawable.BitmapDrawable;
-import android.media.ThumbnailUtils;
-import android.net.Uri;
-import android.provider.MediaStore;
-import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
-import android.widget.TextView;
-import android.widget.VideoView;
-
-import com.github.derlio.waveform.SimpleWaveformView;
-import com.github.derlio.waveform.soundfile.SoundFile;
 
 import org.havenapp.main.R;
 import org.havenapp.main.model.EventTrigger;
 import org.havenapp.main.resources.IResourceManager;
+import org.havenapp.main.ui.viewholder.AudioVH;
+import org.havenapp.main.ui.viewholder.EventTriggerVH;
+import org.havenapp.main.ui.viewholder.ImageVH;
+import org.havenapp.main.ui.viewholder.VideoVH;
 
-import java.io.File;
 import java.util.List;
 
 import androidx.annotation.NonNull;
@@ -30,15 +22,13 @@ import nl.changer.audiowife.AudioWife;
  * Created by n8fr8 on 4/16/17.
  */
 
-public class EventTriggerAdapter extends RecyclerView.Adapter<EventTriggerAdapter.EventTriggerVH> {
+public class EventTriggerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
     private Context context;
     private IResourceManager resourceManager;
     private List<EventTrigger> eventTriggers;
 
     private EventTriggerClickListener eventTriggerClickListener;
-
-    private final static String AUTHORITY = "org.havenapp.main.fileprovider";
 
     EventTriggerAdapter(Context context, @NonNull List<EventTrigger> eventTriggers,
                         IResourceManager resourceManager, EventTriggerClickListener eventTriggerClickListener) {
@@ -55,129 +45,59 @@ public class EventTriggerAdapter extends RecyclerView.Adapter<EventTriggerAdapte
 
     @NonNull
     @Override
-    public EventTriggerVH onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_event, parent, false);
+    public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
 
-        return new EventTriggerVH(view);
+        switch (viewType) {
+            case EventTrigger.CAMERA_VIDEO:
+                return new VideoVH(eventTriggerClickListener, context, resourceManager, parent);
+            case EventTrigger.CAMERA:
+                return new ImageVH(resourceManager, eventTriggerClickListener, parent);
+            case EventTrigger.MICROPHONE:
+                return new AudioVH(resourceManager, parent);
+            case EventTrigger.ACCELEROMETER:
+            case EventTrigger.LIGHT:
+            case EventTrigger.PRESSURE:
+            case EventTrigger.POWER:
+                return new EventTriggerVH(resourceManager, parent);
+        }
+        return new RecyclerView.ViewHolder(new View(context)) {};
     }
 
     @Override
-    public void onBindViewHolder(@NonNull EventTriggerVH holder, int position) {
+    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
 
         final EventTrigger eventTrigger = eventTriggers.get(position);
 
-        String title = eventTrigger.getStringType(resourceManager);
-        String desc = eventTrigger.getTime().toLocaleString();
-
-        holder.image.setVisibility(View.GONE);
-        holder.video.setVisibility(View.GONE);
-        holder.extra.setVisibility(View.GONE);
-        holder.sound.setVisibility(View.GONE);
-
-
-        if (eventTrigger.getPath() != null)
+        if (eventTrigger.getPath() != null && eventTrigger.getType() != null)
         {
             switch (eventTrigger.getType()) {
                 case EventTrigger.CAMERA_VIDEO:
-                    holder.video.setVisibility(View.VISIBLE);
-                    BitmapDrawable bitmapD = new BitmapDrawable(context.getResources(),
-                            ThumbnailUtils.createVideoThumbnail(eventTrigger.getPath(),
-                            MediaStore.Video.Thumbnails.FULL_SCREEN_KIND));
-                    holder.video.setBackground(bitmapD);
-                    holder.video.setOnClickListener(view -> {
-                        if (eventTriggerClickListener != null) {
-                            eventTriggerClickListener.onVideoClick(eventTrigger);
-                        }
-                    });
-
-                    holder.video.setOnLongClickListener(view -> {
-                        if (eventTriggerClickListener != null) {
-                            eventTriggerClickListener.onVideoLongClick(eventTrigger);
-                        }
-                        return false;
-                    });
+                    ((VideoVH) holder).bind(eventTrigger);
                     break;
                 case EventTrigger.CAMERA:
-                    holder.image.setVisibility(View.VISIBLE);
-
-                    /**
-                    Uri fileUri = FileProvider.getUriForFile(
-                            context,
-                            AUTHORITY,
-                            new File(eventTrigger.getPath()));
-                    holder.image.setImageURI(fileUri);
-                    **/
-
-                    Uri fileUri = Uri.parse("file://" + eventTrigger.getPath());
-                    holder.image.setImageURI(fileUri);
-
-
-                    holder.image.setOnClickListener(view -> {
-                        if (eventTriggerClickListener != null)
-                            eventTriggerClickListener.onImageClick(eventTrigger);
-                    });
-
-                    holder.image.setOnLongClickListener(view -> {
-                        if (eventTriggerClickListener != null)
-                            eventTriggerClickListener.onImageLongClick(eventTrigger);
-                        return false;
-                    });
+                    ((ImageVH) holder).bind(eventTrigger);
                     break;
                 case EventTrigger.MICROPHONE:
-                    LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-
-                    holder.sound.setVisibility(View.VISIBLE);
-                    final File fileSound = new File(eventTrigger.getPath());
-                    try {
-                        final SoundFile soundFile = SoundFile.create(fileSound.getPath(), new SoundFile.ProgressListener() {
-                            int lastProgress = 0;
-
-                            @Override
-                            public boolean reportProgress(double fractionComplete) {
-                                final int progress = (int) (fractionComplete * 100);
-                                if (lastProgress == progress) {
-                                    return true;
-                                }
-                                lastProgress = progress;
-
-                                return true;
-                            }
-                        });
-                        holder.sound.setAudioFile(soundFile);
-                        holder.sound.invalidate();
-                    } catch (Exception e) {
-                    }
-
-                    holder.extra.setVisibility(View.VISIBLE);
-                    holder.extra.removeAllViews();
-
-                    AudioWife audioWife = new AudioWife();
-                    audioWife.init(context, Uri.fromFile(fileSound))
-                            .useDefaultUi(holder.extra, inflater);
-
+                    ((AudioVH) holder).bind(eventTrigger, context);
                     break;
                 case EventTrigger.ACCELEROMETER:
-                    desc += "\n" + resourceManager.getString(R.string.data_speed) + ": " + eventTrigger.getPath();
-
+                    ((EventTriggerVH) holder)
+                            .bind(eventTrigger, resourceManager.getString(R.string.data_speed));
                     break;
                 case EventTrigger.LIGHT:
-                    desc += "\n" + resourceManager.getString(R.string.data_light) + ": " + eventTrigger.getPath();
-
+                    ((EventTriggerVH) holder)
+                            .bind(eventTrigger, resourceManager.getString(R.string.data_light));
                     break;
                 case EventTrigger.PRESSURE:
-                    desc += "\n" + resourceManager.getString(R.string.data_pressure) + ": " + eventTrigger.getPath();
+                    ((EventTriggerVH) holder)
+                            .bind(eventTrigger, resourceManager.getString(R.string.data_pressure));
                     break;
                 case EventTrigger.POWER:
-                    desc += "\n" + resourceManager.getString(R.string.data_power) + ": " + eventTrigger.getPath();
+                    ((EventTriggerVH) holder)
+                            .bind(eventTrigger, resourceManager.getString(R.string.data_power));
                     break;
             }
-
         }
-
-        holder.title.setText(title);
-        holder.note.setText(desc);
-
-
     }
 
     @Override
@@ -192,32 +112,11 @@ public class EventTriggerAdapter extends RecyclerView.Adapter<EventTriggerAdapte
         return eventTriggers.size();
     }
 
-    class EventTriggerVH extends RecyclerView.ViewHolder {
-        TextView title, note;
-        ImageView image;
-        VideoView video;
-        ViewGroup extra;
-        SimpleWaveformView sound;
-        EventTriggerVH(View itemView) {
-            super(itemView);
-
-           title = itemView.findViewById(R.id.event_item_title);
-            note = itemView.findViewById(R.id.event_item_desc);
-            image = itemView.findViewById(R.id.event_item_image);
-            video = itemView.findViewById(R.id.event_item_video);
-            extra = itemView.findViewById(R.id.event_item_extra);
-            sound = itemView.findViewById(R.id.event_item_sound);
-        }
+    @Override
+    public int getItemViewType(int position) {
+        return eventTriggers.get(position).getType();
     }
 
-    public interface EventTriggerClickListener {
-        void onVideoClick(EventTrigger eventTrigger);
-
-        void onVideoLongClick(EventTrigger eventTrigger);
-
-        void onImageClick(EventTrigger eventTrigger);
-
-        void onImageLongClick(EventTrigger eventTrigger);
-    }
-
+    public interface EventTriggerClickListener extends VideoVH.VideoClickListener,
+            ImageVH.ImageClickListener {}
 }

--- a/src/main/java/org/havenapp/main/ui/EventTriggerAdapter.java
+++ b/src/main/java/org/havenapp/main/ui/EventTriggerAdapter.java
@@ -75,7 +75,7 @@ public class EventTriggerAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                     ((VideoVH) holder).bind(eventTrigger);
                     break;
                 case EventTrigger.CAMERA:
-                    ((ImageVH) holder).bind(eventTrigger);
+                    ((ImageVH) holder).bind(eventTrigger, position);
                     break;
                 case EventTrigger.MICROPHONE:
                     ((AudioVH) holder).bind(eventTrigger, context);

--- a/src/main/java/org/havenapp/main/ui/EventTriggerAdapter.java
+++ b/src/main/java/org/havenapp/main/ui/EventTriggerAdapter.java
@@ -72,29 +72,29 @@ public class EventTriggerAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
         {
             switch (eventTrigger.getType()) {
                 case EventTrigger.CAMERA_VIDEO:
-                    ((VideoVH) holder).bind(eventTrigger);
+                    ((VideoVH) holder).bind(eventTrigger, position);
                     break;
                 case EventTrigger.CAMERA:
                     ((ImageVH) holder).bind(eventTrigger, position);
                     break;
                 case EventTrigger.MICROPHONE:
-                    ((AudioVH) holder).bind(eventTrigger, context);
+                    ((AudioVH) holder).bind(eventTrigger, context, position);
                     break;
                 case EventTrigger.ACCELEROMETER:
                     ((EventTriggerVH) holder)
-                            .bind(eventTrigger, resourceManager.getString(R.string.data_speed));
+                            .bind(eventTrigger, resourceManager.getString(R.string.data_speed), position);
                     break;
                 case EventTrigger.LIGHT:
                     ((EventTriggerVH) holder)
-                            .bind(eventTrigger, resourceManager.getString(R.string.data_light));
+                            .bind(eventTrigger, resourceManager.getString(R.string.data_light), position);
                     break;
                 case EventTrigger.PRESSURE:
                     ((EventTriggerVH) holder)
-                            .bind(eventTrigger, resourceManager.getString(R.string.data_pressure));
+                            .bind(eventTrigger, resourceManager.getString(R.string.data_pressure), position);
                     break;
                 case EventTrigger.POWER:
                     ((EventTriggerVH) holder)
-                            .bind(eventTrigger, resourceManager.getString(R.string.data_power));
+                            .bind(eventTrigger, resourceManager.getString(R.string.data_power), position);
                     break;
             }
         }

--- a/src/main/java/org/havenapp/main/ui/EventTriggerAdapter.java
+++ b/src/main/java/org/havenapp/main/ui/EventTriggerAdapter.java
@@ -58,6 +58,7 @@ public class EventTriggerAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             case EventTrigger.LIGHT:
             case EventTrigger.PRESSURE:
             case EventTrigger.POWER:
+            case EventTrigger.BUMP:
                 return new EventTriggerVH(resourceManager, parent);
         }
         return new RecyclerView.ViewHolder(new View(context)) {};
@@ -81,6 +82,7 @@ public class EventTriggerAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                     ((AudioVH) holder).bind(eventTrigger, context, position);
                     break;
                 case EventTrigger.ACCELEROMETER:
+                case EventTrigger.BUMP:
                     ((EventTriggerVH) holder)
                             .bind(eventTrigger, resourceManager.getString(R.string.data_speed), position);
                     break;

--- a/src/main/java/org/havenapp/main/ui/viewholder/AudioVH.kt
+++ b/src/main/java/org/havenapp/main/ui/viewholder/AudioVH.kt
@@ -22,12 +22,14 @@ class AudioVH(private val resourceManager: IResourceManager, viewGroup: ViewGrou
     : RecyclerView.ViewHolder(LayoutInflater.from(viewGroup.context)
         .inflate(R.layout.item_audio, viewGroup, false)) {
 
+    private val indexNumber = itemView.findViewById<TextView>(R.id.index_number)
     private val audioTitle = itemView.findViewById<TextView>(R.id.item_audio_title)
     private val audioDesc = itemView.findViewById<TextView>(R.id.item_audio_desc)
     private val waveFormView = itemView.findViewById<SimpleWaveformView>(R.id.item_sound)
     private val playerContainer = itemView.findViewById<LinearLayout>(R.id.item_player_container)
 
-    fun bind(eventTrigger: EventTrigger, context: Context) {
+    fun bind(eventTrigger: EventTrigger, context: Context, position: Int) {
+        indexNumber.text = "#${position + 1}"
         audioTitle.text = eventTrigger.getStringType(resourceManager)
         audioDesc.text = eventTrigger.time?.toLocaleString() ?: ""
 

--- a/src/main/java/org/havenapp/main/ui/viewholder/AudioVH.kt
+++ b/src/main/java/org/havenapp/main/ui/viewholder/AudioVH.kt
@@ -23,7 +23,7 @@ class AudioVH(private val resourceManager: IResourceManager, viewGroup: ViewGrou
         .inflate(R.layout.item_audio, viewGroup, false)) {
 
     private val indexNumber = itemView.findViewById<TextView>(R.id.index_number)
-    private val audioTitle = itemView.findViewById<TextView>(R.id.item_audio_title)
+    private val audioTitle = itemView.findViewById<TextView>(R.id.title)
     private val audioDesc = itemView.findViewById<TextView>(R.id.item_audio_desc)
     private val waveFormView = itemView.findViewById<SimpleWaveformView>(R.id.item_sound)
     private val playerContainer = itemView.findViewById<LinearLayout>(R.id.item_player_container)

--- a/src/main/java/org/havenapp/main/ui/viewholder/AudioVH.kt
+++ b/src/main/java/org/havenapp/main/ui/viewholder/AudioVH.kt
@@ -1,0 +1,61 @@
+package org.havenapp.main.ui.viewholder
+
+import android.content.Context
+import android.net.Uri
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.github.derlio.waveform.SimpleWaveformView
+import com.github.derlio.waveform.soundfile.SoundFile
+import nl.changer.audiowife.AudioWife
+import org.havenapp.main.R
+import org.havenapp.main.model.EventTrigger
+import org.havenapp.main.resources.IResourceManager
+import java.io.File
+
+/**
+ * Created by Arka Prava Basu<arkaprava94@gmail.com> on 21/02/19
+ **/
+class AudioVH(private val resourceManager: IResourceManager, viewGroup: ViewGroup)
+    : RecyclerView.ViewHolder(LayoutInflater.from(viewGroup.context)
+        .inflate(R.layout.item_audio, viewGroup, false)) {
+
+    private val audioTitle = itemView.findViewById<TextView>(R.id.item_audio_title)
+    private val audioDesc = itemView.findViewById<TextView>(R.id.item_audio_desc)
+    private val waveFormView = itemView.findViewById<SimpleWaveformView>(R.id.item_sound)
+    private val playerContainer = itemView.findViewById<LinearLayout>(R.id.item_player_container)
+
+    fun bind(eventTrigger: EventTrigger, context: Context) {
+        audioTitle.text = eventTrigger.getStringType(resourceManager)
+        audioDesc.text = eventTrigger.time?.toLocaleString() ?: ""
+
+        val inflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+
+        val fileSound = File(eventTrigger.path)
+        try {
+            val soundFile = SoundFile.create(fileSound.path, object : SoundFile.ProgressListener {
+                var lastProgress = 0
+
+                override fun reportProgress(fractionComplete: Double): Boolean {
+                    val progress = (fractionComplete * 100).toInt()
+                    if (lastProgress == progress) {
+                        return true
+                    }
+                    lastProgress = progress
+
+                    return true
+                }
+            })
+            waveFormView.setAudioFile(soundFile)
+            waveFormView.invalidate()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+
+        playerContainer.removeAllViews()
+
+        AudioWife().init(context, Uri.fromFile(fileSound)).useDefaultUi(playerContainer, inflater)
+    }
+}

--- a/src/main/java/org/havenapp/main/ui/viewholder/EventTriggerVH.kt
+++ b/src/main/java/org/havenapp/main/ui/viewholder/EventTriggerVH.kt
@@ -22,6 +22,7 @@ class EventTriggerVH(private val resourceManager: IResourceManager, viewGroup: V
     fun bind(eventTrigger: EventTrigger, string: String, position: Int) {
         indexNumber.text = "#${position + 1}"
         triggerTitle.text = eventTrigger.getStringType(resourceManager)
-        triggerDesc.text = """${eventTrigger.time?.toLocaleString() ?: ""}\n$string: ${eventTrigger.path}"""
+        triggerDesc.text = """${eventTrigger.time?.toLocaleString() ?: ""}
+            |$string: ${eventTrigger.path}""".trimMargin()
     }
 }

--- a/src/main/java/org/havenapp/main/ui/viewholder/EventTriggerVH.kt
+++ b/src/main/java/org/havenapp/main/ui/viewholder/EventTriggerVH.kt
@@ -1,0 +1,25 @@
+package org.havenapp.main.ui.viewholder
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import org.havenapp.main.R
+import org.havenapp.main.model.EventTrigger
+import org.havenapp.main.resources.IResourceManager
+
+/**
+ * Created by Arka Prava Basu<arkaprava94@gmail.com> on 21/02/19
+ **/
+class EventTriggerVH(private val resourceManager: IResourceManager, viewGroup: ViewGroup)
+    : RecyclerView.ViewHolder(LayoutInflater.from(viewGroup.context)
+        .inflate(R.layout.item_event_trigger, viewGroup, false)) {
+
+    private val triggerTitle = itemView.findViewById<TextView>(R.id.item_trigger_title)
+    private val triggerDesc = itemView.findViewById<TextView>(R.id.item_trigger_desc)
+
+    fun bind(eventTrigger: EventTrigger, string: String) {
+        triggerTitle.text = eventTrigger.getStringType(resourceManager)
+        triggerDesc.text = """${eventTrigger.time?.toLocaleString() ?: ""}\n$string: ${eventTrigger.path}"""
+    }
+}

--- a/src/main/java/org/havenapp/main/ui/viewholder/EventTriggerVH.kt
+++ b/src/main/java/org/havenapp/main/ui/viewholder/EventTriggerVH.kt
@@ -16,7 +16,7 @@ class EventTriggerVH(private val resourceManager: IResourceManager, viewGroup: V
         .inflate(R.layout.item_event_trigger, viewGroup, false)) {
 
     private val indexNumber = itemView.findViewById<TextView>(R.id.index_number)
-    private val triggerTitle = itemView.findViewById<TextView>(R.id.item_trigger_title)
+    private val triggerTitle = itemView.findViewById<TextView>(R.id.title)
     private val triggerDesc = itemView.findViewById<TextView>(R.id.item_trigger_desc)
 
     fun bind(eventTrigger: EventTrigger, string: String, position: Int) {

--- a/src/main/java/org/havenapp/main/ui/viewholder/EventTriggerVH.kt
+++ b/src/main/java/org/havenapp/main/ui/viewholder/EventTriggerVH.kt
@@ -15,10 +15,12 @@ class EventTriggerVH(private val resourceManager: IResourceManager, viewGroup: V
     : RecyclerView.ViewHolder(LayoutInflater.from(viewGroup.context)
         .inflate(R.layout.item_event_trigger, viewGroup, false)) {
 
+    private val indexNumber = itemView.findViewById<TextView>(R.id.index_number)
     private val triggerTitle = itemView.findViewById<TextView>(R.id.item_trigger_title)
     private val triggerDesc = itemView.findViewById<TextView>(R.id.item_trigger_desc)
 
-    fun bind(eventTrigger: EventTrigger, string: String) {
+    fun bind(eventTrigger: EventTrigger, string: String, position: Int) {
+        indexNumber.text = "#${position + 1}"
         triggerTitle.text = eventTrigger.getStringType(resourceManager)
         triggerDesc.text = """${eventTrigger.time?.toLocaleString() ?: ""}\n$string: ${eventTrigger.path}"""
     }

--- a/src/main/java/org/havenapp/main/ui/viewholder/ImageVH.kt
+++ b/src/main/java/org/havenapp/main/ui/viewholder/ImageVH.kt
@@ -19,7 +19,7 @@ class ImageVH(private val resourceManager: IResourceManager,
         .inflate(R.layout.item_photo, viewGroup, false)) {
 
     private val indexNumber = itemView.findViewById<TextView>(R.id.index_number)
-    private val imageTitle = itemView.findViewById<TextView>(R.id.item_camera_title)
+    private val imageTitle = itemView.findViewById<TextView>(R.id.title)
     private val imageDesc = itemView.findViewById<TextView>(R.id.item_camera_desc)
     private val imageView = itemView.findViewById<SimpleDraweeView>(R.id.item_camera_image)
 

--- a/src/main/java/org/havenapp/main/ui/viewholder/ImageVH.kt
+++ b/src/main/java/org/havenapp/main/ui/viewholder/ImageVH.kt
@@ -22,7 +22,7 @@ class ImageVH(private val resourceManager: IResourceManager,
     private val imageDesc = itemView.findViewById<TextView>(R.id.item_camera_desc)
     private val imageView = itemView.findViewById<SimpleDraweeView>(R.id.item_camera_image)
 
-    fun bind(eventTrigger: EventTrigger) {
+    fun bind(eventTrigger: EventTrigger, position: Int) {
         imageTitle.text = eventTrigger.getStringType(resourceManager)
         imageDesc.text = eventTrigger.time?.toLocaleString() ?: ""
 
@@ -39,7 +39,7 @@ class ImageVH(private val resourceManager: IResourceManager,
 
 
         imageView.setOnClickListener {
-            listener.onImageClick(eventTrigger)
+            listener.onImageClick(eventTrigger, position)
         }
 
         imageView.setOnLongClickListener {
@@ -49,7 +49,7 @@ class ImageVH(private val resourceManager: IResourceManager,
     }
 
     interface ImageClickListener {
-        fun onImageClick(eventTrigger: EventTrigger)
+        fun onImageClick(eventTrigger: EventTrigger, position: Int)
 
         fun onImageLongClick(eventTrigger: EventTrigger)
     }

--- a/src/main/java/org/havenapp/main/ui/viewholder/ImageVH.kt
+++ b/src/main/java/org/havenapp/main/ui/viewholder/ImageVH.kt
@@ -18,11 +18,13 @@ class ImageVH(private val resourceManager: IResourceManager,
     : RecyclerView.ViewHolder(LayoutInflater.from(viewGroup.context)
         .inflate(R.layout.item_photo, viewGroup, false)) {
 
+    private val indexNumber = itemView.findViewById<TextView>(R.id.index_number)
     private val imageTitle = itemView.findViewById<TextView>(R.id.item_camera_title)
     private val imageDesc = itemView.findViewById<TextView>(R.id.item_camera_desc)
     private val imageView = itemView.findViewById<SimpleDraweeView>(R.id.item_camera_image)
 
     fun bind(eventTrigger: EventTrigger, position: Int) {
+        indexNumber.text = "#${position + 1}"
         imageTitle.text = eventTrigger.getStringType(resourceManager)
         imageDesc.text = eventTrigger.time?.toLocaleString() ?: ""
 

--- a/src/main/java/org/havenapp/main/ui/viewholder/ImageVH.kt
+++ b/src/main/java/org/havenapp/main/ui/viewholder/ImageVH.kt
@@ -1,0 +1,56 @@
+package org.havenapp.main.ui.viewholder
+
+import android.net.Uri
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.facebook.drawee.view.SimpleDraweeView
+import org.havenapp.main.R
+import org.havenapp.main.model.EventTrigger
+import org.havenapp.main.resources.IResourceManager
+
+/**
+ * Created by Arka Prava Basu<arkaprava94@gmail.com> on 21/02/19
+ **/
+class ImageVH(private val resourceManager: IResourceManager,
+              private val listener: ImageClickListener, viewGroup: ViewGroup)
+    : RecyclerView.ViewHolder(LayoutInflater.from(viewGroup.context)
+        .inflate(R.layout.item_photo, viewGroup, false)) {
+
+    private val imageTitle = itemView.findViewById<TextView>(R.id.item_camera_title)
+    private val imageDesc = itemView.findViewById<TextView>(R.id.item_camera_desc)
+    private val imageView = itemView.findViewById<SimpleDraweeView>(R.id.item_camera_image)
+
+    fun bind(eventTrigger: EventTrigger) {
+        imageTitle.text = eventTrigger.getStringType(resourceManager)
+        imageDesc.text = eventTrigger.time?.toLocaleString() ?: ""
+
+        /**
+        Uri fileUri = FileProvider.getUriForFile(
+        context,
+        AUTHORITY,
+        new File(eventTrigger.getPath()));
+        holder.image.setImageURI(fileUri);
+         **/
+
+        val fileUri = Uri.parse("file://" + eventTrigger.path!!)
+        imageView.setImageURI(fileUri)
+
+
+        imageView.setOnClickListener {
+            listener.onImageClick(eventTrigger)
+        }
+
+        imageView.setOnLongClickListener {
+            listener.onImageLongClick(eventTrigger)
+            false
+        }
+    }
+
+    interface ImageClickListener {
+        fun onImageClick(eventTrigger: EventTrigger)
+
+        fun onImageLongClick(eventTrigger: EventTrigger)
+    }
+}

--- a/src/main/java/org/havenapp/main/ui/viewholder/VideoVH.kt
+++ b/src/main/java/org/havenapp/main/ui/viewholder/VideoVH.kt
@@ -22,7 +22,7 @@ class VideoVH(private val clickListener: VideoClickListener, private val context
         .inflate(R.layout.item_video, viewGroup, false)) {
 
     private val indexNumber = itemView.findViewById<TextView>(R.id.index_number)
-    private val title = itemView.findViewById<TextView>(R.id.item_video_title)
+    private val title = itemView.findViewById<TextView>(R.id.title)
     private val desc = itemView.findViewById<TextView>(R.id.item_video_desc)
     private val videoView = itemView.findViewById<VideoView>(R.id.item_video_view)
 

--- a/src/main/java/org/havenapp/main/ui/viewholder/VideoVH.kt
+++ b/src/main/java/org/havenapp/main/ui/viewholder/VideoVH.kt
@@ -21,11 +21,13 @@ class VideoVH(private val clickListener: VideoClickListener, private val context
     : RecyclerView.ViewHolder(LayoutInflater.from(viewGroup.context)
         .inflate(R.layout.item_video, viewGroup, false)) {
 
+    private val indexNumber = itemView.findViewById<TextView>(R.id.index_number)
     private val title = itemView.findViewById<TextView>(R.id.item_video_title)
     private val desc = itemView.findViewById<TextView>(R.id.item_video_desc)
     private val videoView = itemView.findViewById<VideoView>(R.id.item_video_view)
 
-    fun bind(eventTrigger: EventTrigger) {
+    fun bind(eventTrigger: EventTrigger, position: Int) {
+        indexNumber.text = "#${position + 1}"
         title.text = eventTrigger.getStringType(resourceManager)
         desc.text = eventTrigger.time?.toLocaleString() ?: ""
 

--- a/src/main/java/org/havenapp/main/ui/viewholder/VideoVH.kt
+++ b/src/main/java/org/havenapp/main/ui/viewholder/VideoVH.kt
@@ -1,0 +1,51 @@
+package org.havenapp.main.ui.viewholder
+
+import android.content.Context
+import android.graphics.drawable.BitmapDrawable
+import android.media.ThumbnailUtils
+import android.provider.MediaStore
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.TextView
+import android.widget.VideoView
+import androidx.recyclerview.widget.RecyclerView
+import org.havenapp.main.R
+import org.havenapp.main.model.EventTrigger
+import org.havenapp.main.resources.IResourceManager
+
+/**
+ * Created by Arka Prava Basu<arkaprava94@gmail.com> on 21/02/19
+ **/
+class VideoVH(private val clickListener: VideoClickListener, private val context: Context,
+              private val resourceManager: IResourceManager, viewGroup: ViewGroup)
+    : RecyclerView.ViewHolder(LayoutInflater.from(viewGroup.context)
+        .inflate(R.layout.item_video, viewGroup, false)) {
+
+    private val title = itemView.findViewById<TextView>(R.id.item_video_title)
+    private val desc = itemView.findViewById<TextView>(R.id.item_video_desc)
+    private val videoView = itemView.findViewById<VideoView>(R.id.item_video_view)
+
+    fun bind(eventTrigger: EventTrigger) {
+        title.text = eventTrigger.getStringType(resourceManager)
+        desc.text = eventTrigger.time?.toLocaleString() ?: ""
+
+        val bitmapD = BitmapDrawable(context.resources,
+                ThumbnailUtils.createVideoThumbnail(eventTrigger.path,
+                        MediaStore.Video.Thumbnails.FULL_SCREEN_KIND))
+        videoView.background = bitmapD
+        videoView.setOnClickListener {
+            clickListener.onVideoClick(eventTrigger)
+        }
+
+        videoView.setOnLongClickListener {
+            clickListener.onVideoLongClick(eventTrigger)
+            false
+        }
+    }
+
+    interface VideoClickListener {
+        fun onVideoClick(eventTrigger: EventTrigger)
+
+        fun onVideoLongClick(eventTrigger: EventTrigger)
+    }
+}

--- a/src/main/res/layout/item_audio.xml
+++ b/src/main/res/layout/item_audio.xml
@@ -16,6 +16,13 @@
         android:padding="@dimen/activity_margin_half">
 
         <TextView
+            android:id="@+id/index_number"
+            android:textColor="#808080"
+            android:textSize="12sp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <TextView
             android:id="@+id/item_audio_title"
             style="@style/TextAppearance.AppCompat.Title"
             android:layout_width="match_parent"

--- a/src/main/res/layout/item_audio.xml
+++ b/src/main/res/layout/item_audio.xml
@@ -15,19 +15,31 @@
         android:orientation="vertical"
         android:padding="@dimen/activity_margin_half">
 
-        <TextView
-            android:id="@+id/index_number"
-            android:textColor="#808080"
-            android:textSize="12sp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
-
-        <TextView
-            android:id="@+id/item_audio_title"
-            style="@style/TextAppearance.AppCompat.Title"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            tools:text="Title" />
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/item_audio_title"
+                style="@style/TextAppearance.AppCompat.Title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                tools:text="Title" />
+
+            <TextView
+                android:id="@+id/index_number"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_marginLeft="4dp"
+                android:textColor="#808080"
+                android:textSize="12sp"
+                tools:text="#123" />
+
+        </LinearLayout>
 
         <com.github.derlio.waveform.SimpleWaveformView
             android:id="@+id/item_sound"

--- a/src/main/res/layout/item_audio.xml
+++ b/src/main/res/layout/item_audio.xml
@@ -15,31 +15,8 @@
         android:orientation="vertical"
         android:padding="@dimen/activity_margin_half">
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/item_audio_title"
-                style="@style/TextAppearance.AppCompat.Title"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                tools:text="Title" />
-
-            <TextView
-                android:id="@+id/index_number"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="4dp"
-                android:layout_marginLeft="4dp"
-                android:textColor="#808080"
-                android:textSize="12sp"
-                tools:text="#123" />
-
-        </LinearLayout>
+        <include
+            layout="@layout/item_header" />
 
         <com.github.derlio.waveform.SimpleWaveformView
             android:id="@+id/item_sound"

--- a/src/main/res/layout/item_audio.xml
+++ b/src/main/res/layout/item_audio.xml
@@ -2,10 +2,10 @@
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/note_item"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="@dimen/activity_margin_half"
+    android:background="?attr/selectableItemBackground"
     android:orientation="vertical">
 
     <LinearLayout
@@ -16,21 +16,30 @@
         android:padding="@dimen/activity_margin_half">
 
         <TextView
-            android:id="@+id/event_item_title"
+            android:id="@+id/item_audio_title"
             style="@style/TextAppearance.AppCompat.Title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             tools:text="Title" />
 
-        <RelativeLayout
+        <com.github.derlio.waveform.SimpleWaveformView
+            android:id="@+id/item_sound"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/activity_margin_half"
-            android:paddingRight="4dp"
-            android:paddingLeft="4dp">
+            android:layout_height="144dp"
+            app:indicatorColor="@color/colorPrimaryDark"
+            app:waveformColor="@color/colorAccent" />
+
+        <LinearLayout
+            android:id="@+id/item_player_container"
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:gravity="center_vertical"
+            android:orientation="vertical"
+            android:paddingLeft="4dp"
+            android:paddingRight="4dp" />
 
         <TextView
-            android:id="@+id/event_item_desc"
+            android:id="@+id/item_audio_desc"
             style="@style/TextAppearance.AppCompat.Body1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -40,17 +49,6 @@
             android:paddingBottom="@dimen/activity_margin_half"
             android:textColor="@android:color/black"
             tools:text="Description" />
-
-            <ImageView
-                android:id="@+id/event_action_share"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentRight="true"
-                android:visibility="gone"
-                android:tint="@android:color/black"
-                app:srcCompat="@drawable/ic_share" />
-        </RelativeLayout>
 
     </LinearLayout>
 

--- a/src/main/res/layout/item_event.xml
+++ b/src/main/res/layout/item_event.xml
@@ -15,31 +15,8 @@
         android:orientation="vertical"
         android:padding="@dimen/activity_margin_half">
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/event_item_title"
-                style="@style/TextAppearance.AppCompat.Title"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                tools:text="Title" />
-
-            <TextView
-                android:id="@+id/index_number"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="4dp"
-                android:layout_marginLeft="4dp"
-                android:textColor="#808080"
-                android:textSize="12sp"
-                tools:text="#123" />
-
-        </LinearLayout>
+        <include
+            layout="@layout/item_header" />
 
         <RelativeLayout
             android:layout_width="match_parent"

--- a/src/main/res/layout/item_event.xml
+++ b/src/main/res/layout/item_event.xml
@@ -16,6 +16,13 @@
         android:padding="@dimen/activity_margin_half">
 
         <TextView
+            android:id="@+id/index_number"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="#808080"
+            android:textSize="12sp" />
+
+        <TextView
             android:id="@+id/event_item_title"
             style="@style/TextAppearance.AppCompat.Title"
             android:layout_width="match_parent"
@@ -26,20 +33,20 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/activity_margin_half"
-            android:paddingRight="4dp"
-            android:paddingLeft="4dp">
+            android:paddingLeft="4dp"
+            android:paddingRight="4dp">
 
-        <TextView
-            android:id="@+id/event_item_desc"
-            style="@style/TextAppearance.AppCompat.Body1"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:alpha="0.54"
-            android:ellipsize="end"
-            android:maxLines="6"
-            android:paddingBottom="@dimen/activity_margin_half"
-            android:textColor="@android:color/black"
-            tools:text="Description" />
+            <TextView
+                android:id="@+id/event_item_desc"
+                style="@style/TextAppearance.AppCompat.Body1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:alpha="0.54"
+                android:ellipsize="end"
+                android:maxLines="6"
+                android:paddingBottom="@dimen/activity_margin_half"
+                android:textColor="@android:color/black"
+                tools:text="Description" />
 
             <ImageView
                 android:id="@+id/event_action_share"
@@ -47,8 +54,8 @@
                 android:layout_height="wrap_content"
                 android:layout_alignParentEnd="true"
                 android:layout_alignParentRight="true"
-                android:visibility="gone"
                 android:tint="@android:color/black"
+                android:visibility="gone"
                 app:srcCompat="@drawable/ic_share" />
         </RelativeLayout>
 

--- a/src/main/res/layout/item_event.xml
+++ b/src/main/res/layout/item_event.xml
@@ -15,19 +15,31 @@
         android:orientation="vertical"
         android:padding="@dimen/activity_margin_half">
 
-        <TextView
-            android:id="@+id/index_number"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="#808080"
-            android:textSize="12sp" />
-
-        <TextView
-            android:id="@+id/event_item_title"
-            style="@style/TextAppearance.AppCompat.Title"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            tools:text="Title" />
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/event_item_title"
+                style="@style/TextAppearance.AppCompat.Title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                tools:text="Title" />
+
+            <TextView
+                android:id="@+id/index_number"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_marginLeft="4dp"
+                android:textColor="#808080"
+                android:textSize="12sp"
+                tools:text="#123" />
+
+        </LinearLayout>
 
         <RelativeLayout
             android:layout_width="match_parent"

--- a/src/main/res/layout/item_event_trigger.xml
+++ b/src/main/res/layout/item_event_trigger.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_margin="@dimen/activity_margin_half"
     android:background="?attr/selectableItemBackground"
     android:orientation="vertical">
@@ -13,6 +13,13 @@
         android:background="?attr/selectableItemBackground"
         android:orientation="vertical"
         android:padding="@dimen/activity_margin_half">
+
+        <TextView
+            android:id="@+id/index_number"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="#808080"
+            android:textSize="12sp" />
 
         <TextView
             android:id="@+id/item_trigger_title"

--- a/src/main/res/layout/item_event_trigger.xml
+++ b/src/main/res/layout/item_event_trigger.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/note_item"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_margin="@dimen/activity_margin_half"
+    android:background="?attr/selectableItemBackground"
     android:orientation="vertical">
 
     <LinearLayout
@@ -16,21 +15,14 @@
         android:padding="@dimen/activity_margin_half">
 
         <TextView
-            android:id="@+id/event_item_title"
+            android:id="@+id/item_trigger_title"
             style="@style/TextAppearance.AppCompat.Title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             tools:text="Title" />
 
-        <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/activity_margin_half"
-            android:paddingRight="4dp"
-            android:paddingLeft="4dp">
-
         <TextView
-            android:id="@+id/event_item_desc"
+            android:id="@+id/item_trigger_desc"
             style="@style/TextAppearance.AppCompat.Body1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -40,17 +32,6 @@
             android:paddingBottom="@dimen/activity_margin_half"
             android:textColor="@android:color/black"
             tools:text="Description" />
-
-            <ImageView
-                android:id="@+id/event_action_share"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentRight="true"
-                android:visibility="gone"
-                android:tint="@android:color/black"
-                app:srcCompat="@drawable/ic_share" />
-        </RelativeLayout>
 
     </LinearLayout>
 

--- a/src/main/res/layout/item_event_trigger.xml
+++ b/src/main/res/layout/item_event_trigger.xml
@@ -14,31 +14,8 @@
         android:orientation="vertical"
         android:padding="@dimen/activity_margin_half">
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/item_trigger_title"
-                style="@style/TextAppearance.AppCompat.Title"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                tools:text="Title" />
-
-            <TextView
-                android:id="@+id/index_number"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="4dp"
-                android:layout_marginLeft="4dp"
-                android:textColor="#808080"
-                android:textSize="12sp"
-                tools:text="#123" />
-
-        </LinearLayout>
+        <include
+            layout="@layout/item_header" />
 
         <TextView
             android:id="@+id/item_trigger_desc"

--- a/src/main/res/layout/item_event_trigger.xml
+++ b/src/main/res/layout/item_event_trigger.xml
@@ -14,19 +14,31 @@
         android:orientation="vertical"
         android:padding="@dimen/activity_margin_half">
 
-        <TextView
-            android:id="@+id/index_number"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="#808080"
-            android:textSize="12sp" />
-
-        <TextView
-            android:id="@+id/item_trigger_title"
-            style="@style/TextAppearance.AppCompat.Title"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            tools:text="Title" />
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/item_trigger_title"
+                style="@style/TextAppearance.AppCompat.Title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                tools:text="Title" />
+
+            <TextView
+                android:id="@+id/index_number"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_marginLeft="4dp"
+                android:textColor="#808080"
+                android:textSize="12sp"
+                tools:text="#123" />
+
+        </LinearLayout>
 
         <TextView
             android:id="@+id/item_trigger_desc"

--- a/src/main/res/layout/item_header.xml
+++ b/src/main/res/layout/item_header.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
+
+    <TextView
+        android:id="@+id/title"
+        style="@style/TextAppearance.AppCompat.Title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        tools:text="Title" />
+
+    <TextView
+        android:id="@+id/index_number"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        android:layout_marginLeft="4dp"
+        android:textColor="#808080"
+        android:textSize="12sp"
+        tools:text="#123" />
+
+</LinearLayout>

--- a/src/main/res/layout/item_photo.xml
+++ b/src/main/res/layout/item_photo.xml
@@ -14,31 +14,8 @@
         android:orientation="vertical"
         android:padding="@dimen/activity_margin_half">
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/item_camera_title"
-                style="@style/TextAppearance.AppCompat.Title"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                tools:text="Title" />
-
-            <TextView
-                android:id="@+id/index_number"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="4dp"
-                android:layout_marginLeft="4dp"
-                android:textColor="#808080"
-                android:textSize="12sp"
-                tools:text="#123" />
-
-        </LinearLayout>
+        <include
+            layout="@layout/item_header" />
 
         <com.facebook.drawee.view.SimpleDraweeView
             android:id="@+id/item_camera_image"

--- a/src/main/res/layout/item_photo.xml
+++ b/src/main/res/layout/item_photo.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/note_item"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_margin="@dimen/activity_margin_half"
+    android:background="?attr/selectableItemBackground"
     android:orientation="vertical">
 
     <LinearLayout
@@ -16,21 +15,21 @@
         android:padding="@dimen/activity_margin_half">
 
         <TextView
-            android:id="@+id/event_item_title"
+            android:id="@+id/item_camera_title"
             style="@style/TextAppearance.AppCompat.Title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             tools:text="Title" />
 
-        <RelativeLayout
+        <com.facebook.drawee.view.SimpleDraweeView
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/activity_margin_half"
-            android:paddingRight="4dp"
-            android:paddingLeft="4dp">
+            android:layout_height="200dp"
+            android:id="@+id/item_camera_image"
+            android:scaleType="centerCrop"
+            />
 
         <TextView
-            android:id="@+id/event_item_desc"
+            android:id="@+id/item_camera_desc"
             style="@style/TextAppearance.AppCompat.Body1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -40,17 +39,6 @@
             android:paddingBottom="@dimen/activity_margin_half"
             android:textColor="@android:color/black"
             tools:text="Description" />
-
-            <ImageView
-                android:id="@+id/event_action_share"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentRight="true"
-                android:visibility="gone"
-                android:tint="@android:color/black"
-                app:srcCompat="@drawable/ic_share" />
-        </RelativeLayout>
 
     </LinearLayout>
 

--- a/src/main/res/layout/item_photo.xml
+++ b/src/main/res/layout/item_photo.xml
@@ -14,19 +14,31 @@
         android:orientation="vertical"
         android:padding="@dimen/activity_margin_half">
 
-        <TextView
-            android:id="@+id/index_number"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="#808080"
-            android:textSize="12sp" />
-
-        <TextView
-            android:id="@+id/item_camera_title"
-            style="@style/TextAppearance.AppCompat.Title"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            tools:text="Title" />
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/item_camera_title"
+                style="@style/TextAppearance.AppCompat.Title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                tools:text="Title" />
+
+            <TextView
+                android:id="@+id/index_number"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_marginLeft="4dp"
+                android:textColor="#808080"
+                android:textSize="12sp"
+                tools:text="#123" />
+
+        </LinearLayout>
 
         <com.facebook.drawee.view.SimpleDraweeView
             android:id="@+id/item_camera_image"

--- a/src/main/res/layout/item_photo.xml
+++ b/src/main/res/layout/item_photo.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_margin="@dimen/activity_margin_half"
     android:background="?attr/selectableItemBackground"
     android:orientation="vertical">
@@ -15,6 +15,13 @@
         android:padding="@dimen/activity_margin_half">
 
         <TextView
+            android:id="@+id/index_number"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="#808080"
+            android:textSize="12sp" />
+
+        <TextView
             android:id="@+id/item_camera_title"
             style="@style/TextAppearance.AppCompat.Title"
             android:layout_width="match_parent"
@@ -22,11 +29,10 @@
             tools:text="Title" />
 
         <com.facebook.drawee.view.SimpleDraweeView
+            android:id="@+id/item_camera_image"
             android:layout_width="match_parent"
             android:layout_height="200dp"
-            android:id="@+id/item_camera_image"
-            android:scaleType="centerCrop"
-            />
+            android:scaleType="centerCrop" />
 
         <TextView
             android:id="@+id/item_camera_desc"

--- a/src/main/res/layout/item_video.xml
+++ b/src/main/res/layout/item_video.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/note_item"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_margin="@dimen/activity_margin_half"
+    android:background="?attr/selectableItemBackground"
     android:orientation="vertical">
 
     <LinearLayout
@@ -16,21 +15,21 @@
         android:padding="@dimen/activity_margin_half">
 
         <TextView
-            android:id="@+id/event_item_title"
+            android:id="@+id/item_video_title"
             style="@style/TextAppearance.AppCompat.Title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             tools:text="Title" />
 
-        <RelativeLayout
+        <VideoView
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/activity_margin_half"
-            android:paddingRight="4dp"
-            android:paddingLeft="4dp">
+            android:layout_height="200dp"
+            android:id="@+id/item_video_view"
+            android:scaleType="centerCrop"
+            />
 
         <TextView
-            android:id="@+id/event_item_desc"
+            android:id="@+id/item_video_desc"
             style="@style/TextAppearance.AppCompat.Body1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -40,17 +39,6 @@
             android:paddingBottom="@dimen/activity_margin_half"
             android:textColor="@android:color/black"
             tools:text="Description" />
-
-            <ImageView
-                android:id="@+id/event_action_share"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentRight="true"
-                android:visibility="gone"
-                android:tint="@android:color/black"
-                app:srcCompat="@drawable/ic_share" />
-        </RelativeLayout>
 
     </LinearLayout>
 

--- a/src/main/res/layout/item_video.xml
+++ b/src/main/res/layout/item_video.xml
@@ -14,19 +14,31 @@
         android:orientation="vertical"
         android:padding="@dimen/activity_margin_half">
 
-        <TextView
-            android:id="@+id/index_number"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="#808080"
-            android:textSize="12sp" />
-
-        <TextView
-            android:id="@+id/item_video_title"
-            style="@style/TextAppearance.AppCompat.Title"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            tools:text="Title" />
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/item_video_title"
+                style="@style/TextAppearance.AppCompat.Title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                tools:text="Title" />
+
+            <TextView
+                android:id="@+id/index_number"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_marginLeft="4dp"
+                android:textColor="#808080"
+                android:textSize="12sp"
+                tools:text="#123" />
+
+        </LinearLayout>
 
         <VideoView
             android:id="@+id/item_video_view"

--- a/src/main/res/layout/item_video.xml
+++ b/src/main/res/layout/item_video.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_margin="@dimen/activity_margin_half"
     android:background="?attr/selectableItemBackground"
     android:orientation="vertical">
@@ -15,6 +15,13 @@
         android:padding="@dimen/activity_margin_half">
 
         <TextView
+            android:id="@+id/index_number"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="#808080"
+            android:textSize="12sp" />
+
+        <TextView
             android:id="@+id/item_video_title"
             style="@style/TextAppearance.AppCompat.Title"
             android:layout_width="match_parent"
@@ -22,11 +29,10 @@
             tools:text="Title" />
 
         <VideoView
+            android:id="@+id/item_video_view"
             android:layout_width="match_parent"
             android:layout_height="200dp"
-            android:id="@+id/item_video_view"
-            android:scaleType="centerCrop"
-            />
+            android:scaleType="centerCrop" />
 
         <TextView
             android:id="@+id/item_video_desc"

--- a/src/main/res/layout/item_video.xml
+++ b/src/main/res/layout/item_video.xml
@@ -14,31 +14,8 @@
         android:orientation="vertical"
         android:padding="@dimen/activity_margin_half">
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/item_video_title"
-                style="@style/TextAppearance.AppCompat.Title"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                tools:text="Title" />
-
-            <TextView
-                android:id="@+id/index_number"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="4dp"
-                android:layout_marginLeft="4dp"
-                android:textColor="#808080"
-                android:textSize="12sp"
-                tools:text="#123" />
-
-        </LinearLayout>
+        <include
+            layout="@layout/item_header" />
 
         <VideoView
             android:id="@+id/item_video_view"


### PR DESCRIPTION
Well I started this to eliminate the flicker first time an audio item is inflated. Turns it it is due to the view used to display the Wave form.

Anyways for multiple view type in a recyclerview we should use different layouts. This removes the burden of changing the visibility of items in `onBind`. This multiple view type maps well with the multiple type of `EventTrigger` we have.

This also removes a bug: clicking on any image in Event we always start the ImageViewer with `startPosition = 0`. This should be the index of image clicked.