### PR TITLE
Bug Fix: Prevent triggers getting categorised in wrong folder on disk

### DIFF
--- a/src/main/java/org/havenapp/main/sensors/AccelerometerMonitor.java
+++ b/src/main/java/org/havenapp/main/sensors/AccelerometerMonitor.java
@@ -142,7 +142,7 @@ public class AccelerometerMonitor implements SensorEventListener {
 
                         Message message = new Message();
                         message.what = EventTrigger.ACCELEROMETER;
-                        message.getData().putString("path",mAccel+"");
+                        message.getData().putString(MonitorService.KEY_PATH, mAccel+"");
 
                         try {
                             if (serviceMessenger != null) {

--- a/src/main/java/org/havenapp/main/sensors/AmbientLightMonitor.java
+++ b/src/main/java/org/havenapp/main/sensors/AmbientLightMonitor.java
@@ -121,7 +121,7 @@ public class AmbientLightMonitor implements SensorEventListener {
 
                         Message message = new Message();
                         message.what = EventTrigger.LIGHT;
-                        message.getData().putString("path",lightChangedValue+"");
+                        message.getData().putString(MonitorService.KEY_PATH, lightChangedValue+"");
 
                         try {
                             if (serviceMessenger != null) {

--- a/src/main/java/org/havenapp/main/sensors/BarometerMonitor.java
+++ b/src/main/java/org/havenapp/main/sensors/BarometerMonitor.java
@@ -122,7 +122,7 @@ public class BarometerMonitor implements SensorEventListener {
 
                         Message message = new Message();
                         message.what = EventTrigger.PRESSURE;
-                        message.getData().putString("path",diffValue+"");
+                        message.getData().putString(MonitorService.KEY_PATH, diffValue+"");
 
                         try {
                             if (serviceMessenger != null) {

--- a/src/main/java/org/havenapp/main/sensors/BumpMonitor.java
+++ b/src/main/java/org/havenapp/main/sensors/BumpMonitor.java
@@ -83,7 +83,7 @@ public class BumpMonitor {
                      */
                     Message message = new Message();
                     message.what = EventTrigger.BUMP;
-                    message.getData().putString("path","BUMPED!");
+                    message.getData().putString(MonitorService.KEY_PATH, "BUMPED!");
 
                     try {
                         if (serviceMessenger != null) {

--- a/src/main/java/org/havenapp/main/sensors/MicrophoneMonitor.java
+++ b/src/main/java/org/havenapp/main/sensors/MicrophoneMonitor.java
@@ -151,7 +151,7 @@ public final class MicrophoneMonitor implements MicSamplerTask.MicListener {
 
                             Message message = new Message();
                             message.what = EventTrigger.MICROPHONE;
-                            message.getData().putString("path",path);
+                            message.getData().putString(MonitorService.KEY_PATH, path);
                             try {
                                 if (serviceMessenger != null)
                                     serviceMessenger.send(message);

--- a/src/main/java/org/havenapp/main/service/MonitorService.java
+++ b/src/main/java/org/havenapp/main/service/MonitorService.java
@@ -237,6 +237,9 @@ public class MonitorService extends Service {
     {
         mIsMonitoringActive = true;
 
+        // set current event start date in prefs
+        mPrefs.setCurrentSession(new Date(System.currentTimeMillis()));
+
         if (!mPrefs.getAccelerometerSensitivity().equals(PreferenceManager.OFF)) {
             mAccelManager = new AccelerometerMonitor(this);
             if(Build.VERSION.SDK_INT>=18) {
@@ -316,8 +319,6 @@ public class MonitorService extends Service {
                     .getEventDAO().insert(mLastEvent);
             mLastEvent.setId(eventId);
             doNotification = true;
-            // set current event start date in prefs
-            mPrefs.setCurrentSession(mLastEvent.getStartTime());
         }
         else if (mPrefs.getNotificationTimeMs() == 0)
         {

--- a/src/main/java/org/havenapp/main/ui/CameraViewHolder.java
+++ b/src/main/java/org/havenapp/main/ui/CameraViewHolder.java
@@ -172,7 +172,7 @@ public class CameraViewHolder {
 
                 stream.flush();
                 stream.close();
-                message.getData().putString("path", fileImage.getAbsolutePath());
+                message.getData().putString(MonitorService.KEY_PATH, fileImage.getAbsolutePath());
 
                 //store the still match frame, even if doing video
                 serviceMessenger.send(message);


### PR DESCRIPTION
- setting mPrefs.setCurrentSession() in alert() is errorneous since the file corresponding
  to the `EventTrigger` will be created by then. This will be created with an in-correct path;
  ie, with the session folder corresponding to the previous session.
- trade-off: the session folder will have a timestamp different to that of the `Event`
  start timestamp in the DB (and in UI). This may cause a difficulty in navigating the
  directories in disk.
