### PR TITLE
WIP - LeakCanary investigation to find memory leaks

### DIFF
--- a/src/main/java/org/havenapp/main/ui/CameraViewHolder.java
+++ b/src/main/java/org/havenapp/main/ui/CameraViewHolder.java
@@ -416,7 +416,9 @@ public class CameraViewHolder {
             this.context.unbindService(mConnection);
             mConnection = null;
         }
-        stopCamera();
+        if (cameraView != null) {
+            cameraView.destroy();
+        }
     }
 
     public int getCorrectCameraOrientation(Facing facing, int orientation) {


### PR DESCRIPTION
Call cameraview destroy() instead of close() on Fragment onDestroy()  -> #393 
- destroy() releases the camera resource unlike close() which just stops the preview