### PR TITLE
Update to latest AS and hopefully fix video crash (#410)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,11 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.3.61'
     repositories {
         google()
         jcenter()
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.0.0-alpha08'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 
@@ -37,7 +36,6 @@ repositories {
     jcenter()
     maven { url 'https://github.com/FireZenk/maven-repo/raw/master/' }
     maven { url 'https://jitpack.io' }
-    maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
 }
 
 allprojects {
@@ -145,11 +143,11 @@ configurations {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta3'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta4'
     implementation 'androidx.preference:preference:1.1.0'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.android.material:material:1.2.0-alpha02'
+    implementation 'com.google.android.material:material:1.2.0-alpha03'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.wdullaer:materialdatetimepicker:4.2.3'
     implementation 'com.github.guardianproject:signal-cli-android:v0.6.0-android-beta-1'
@@ -162,7 +160,7 @@ dependencies {
     implementation 'com.facebook.fresco:fresco:2.0.0'
     implementation 'com.github.derlio:audio-waveform:v1.0.1'
     implementation 'com.maxproj.simplewaveform:app:1.0.0'
-    implementation 'com.googlecode.libphonenumber:libphonenumber:8.11.0'
+    implementation 'com.googlecode.libphonenumber:libphonenumber:8.11.1'
     implementation('com.mikepenz:aboutlibraries:7.0.3@aar') {
         transitive = true
     }
@@ -172,7 +170,7 @@ dependencies {
     implementation 'io.github.silvaren:easyrs:0.5.3'
     implementation 'org.jcodec:jcodec:0.2.5'
     implementation 'org.jcodec:jcodec-android:0.2.5'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     // Room
     implementation "android.arch.persistence.room:runtime:2.1.0"
@@ -180,7 +178,7 @@ dependencies {
     implementation "android.arch.lifecycle:runtime:2.1.0"
     implementation "android.arch.lifecycle:extensions:2.1.0"
 
-    testImplementation "junit:junit:4.12"
+    testImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:core:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -144,6 +144,7 @@ configurations {
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta4'
+    implementation "androidx.coordinatorlayout:coordinatorlayout:1.1.0"
     implementation 'androidx.preference:preference:1.1.0'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.annotation:annotation:1.1.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,6 +3,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-rc-3-all.zip
 android.useAndroidX=true
 android.enableD8=true

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -44,7 +44,8 @@
         android:fullBackupContent="@xml/backup_config"
         android:supportsRtl="false"
         tools:replace="android:allowBackup,android:supportsRtl"
-        tools:ignore="GoogleAppIndexingWarning">
+        tools:ignore="GoogleAppIndexingWarning"
+        android:requestLegacyExternalStorage="true">
         <activity
             android:name=".ListActivity"
             android:configChanges="orientation|screenSize"

--- a/src/main/res/layout/activity_video_player.xml
+++ b/src/main/res/layout/activity_video_player.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayoutwidget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -9,7 +9,8 @@
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:theme="@style/AppTheme.AppBarOverlay">
+        android:theme="@style/AppTheme.AppBarOverlay"
+        app:layout_constraintTop_toTopOf="parent">
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
@@ -20,6 +21,8 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <include layout="@layout/content_video_player" />
+    <include
+        android:id="@+id/include"
+        layout="@layout/content_video_player" />
 
-</androidx.constraintlayout.widget.ConstraintLayoutwidget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/src/main/res/layout/content_video_player.xml
+++ b/src/main/res/layout/content_video_player.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -8,7 +8,7 @@
     tools:context=".ui.VideoPlayerActivity"
     tools:showIn="@layout/activity_video_player">
 
-    <com.halilibo.bettervideoplayer.BetterVideoPlayer xmlns:android="http://schemas.android.com/apk/res/android"
+    <com.halilibo.bettervideoplayer.BetterVideoPlayer
         android:id="@+id/player"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -18,4 +18,4 @@
         app:layout_constraintTop_toTopOf="parent" />
 
 
-</androidx.constraintlayout.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
I think these changes should speak for themselves, but the important ones are the AndroidManifest change to support access to external storage in Android 10 and the video player (fixes to ConstraintLayout and CoordinatorLayout).

In my emulator build the video doesn't encode fast enough, so the videos are black, but I dont' know if this is an issue beyond my system.  Didn't test on an actual device-- maybe someone else can.

Build requires recent Android Studio 4 Canary (I'm using 8)

Cheers!
ft