### PR TITLE
set audio encoding to address video bug

### DIFF
--- a/src/main/java/org/havenapp/main/sensors/media/AudioCodec.java
+++ b/src/main/java/org/havenapp/main/sensors/media/AudioCodec.java
@@ -26,13 +26,13 @@ public class AudioCodec {
 	public void start() throws IllegalStateException, IOException {
 		if (recorder == null) {
 			minSize = AudioRecord.getMinBufferSize(
-					8000,
+					44100,
 					AudioFormat.CHANNEL_IN_DEFAULT,
 					AudioFormat.ENCODING_PCM_16BIT);
             Log.e("AudioCodec", "Minimum size is " + minSize);
 			recorder = new AudioRecord(
-					MediaRecorder.AudioSource.MIC, 
-					8000,
+					MediaRecorder.AudioSource.MIC,
+					44100,
 					AudioFormat.CHANNEL_IN_DEFAULT,
 					AudioFormat.ENCODING_PCM_16BIT,
 					minSize);

--- a/src/main/java/org/havenapp/main/sensors/media/MediaRecorderTask.java
+++ b/src/main/java/org/havenapp/main/sensors/media/MediaRecorderTask.java
@@ -43,10 +43,10 @@ public class MediaRecorderTask  {
         mCamera.unlock();
         mMediaRecorder.setCamera(mCamera);
         mMediaRecorder.setPreviewDisplay(mHolder.getSurface());
-    //    mMediaRecorder.setAudioSource(MediaRecorder.AudioSource.MIC);
+        mMediaRecorder.setAudioSource(MediaRecorder.AudioSource.DEFAULT);
         mMediaRecorder.setVideoSource(MediaRecorder.VideoSource.DEFAULT);
         mMediaRecorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
-     //   mMediaRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB);
+        mMediaRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.DEFAULT);
         mMediaRecorder.setVideoEncoder(MediaRecorder.VideoEncoder.MPEG_4_SP);
         mMediaRecorder.setMaxDuration(mSeconds);
         mMediaRecorder.setOutputFile(mOutputFile);


### PR DESCRIPTION
Fix videos not playing/appearing in logs on emulated & physical devices. 

Tested on Nexus 4 AOS 5.1 - Pixel 2 AOS 10.0

