### PR TITLE
fix: docs/preso/plugin/multiplex/package.json to reduce vulnerabilities

### DIFF
--- a/docs/preso/plugin/multiplex/package.json
+++ b/docs/preso/plugin/multiplex/package.json
@@ -10,10 +10,10 @@
     "node": "~4.1.1"
   },
   "dependencies": {
-    "express": "~4.13.3",
-    "grunt-cli": "~0.1.13",
+    "express": "~4.16.0",
+    "grunt-cli": "~1.3.0",
     "mustache": "~2.2.1",
-    "socket.io": "~1.3.7"
+    "socket.io": "~2.0.0"
   },
   "license": "MIT"
 }

--- a/docs/preso/plugin/multiplex/package.json
+++ b/docs/preso/plugin/multiplex/package.json
@@ -10,7 +10,7 @@
     "node": "~4.1.1"
   },
   "dependencies": {
-    "express": "~4.16.0",
+    "express": "~4.17.1",
     "grunt-cli": "~1.3.0",
     "mustache": "~2.2.1",
     "socket.io": "~2.0.0"

--- a/docs/preso/plugin/multiplex/package.json
+++ b/docs/preso/plugin/multiplex/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "express": "~4.17.1",
     "grunt-cli": "~1.3.0",
-    "mustache": "~2.2.1",
+    "mustache": "~2.3.2",
     "socket.io": "~2.0.0"
   },
   "license": "MIT"


### PR DESCRIPTION
<h3>Auto-PR to fix one or more vulnerable packages in the `npm` dependencies of this project.</h3>

#### Changes included in this PR

- Changes to the following files to upgrade the vulnerable dependencies to a fixed version:
    - docs/preso/plugin/multiplex/package.json



#### Vulnerabilities that will be fixed
##### With an upgrade:
Severity                   |  Issue                   | Breaking Change                   | Exploit Maturity
:-------------------------:|:-------------------------|:-------------------------|:-------------------------
![high severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/h.png "high severity") | Prototype Pollution <br/>[SNYK-JS-LODASH-450202](https://snyk.io/vuln/SNYK-JS-LODASH-450202) |  Yes  | Proof of Concept 
![high severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/h.png "high severity") | Prototype Pollution <br/>[SNYK-JS-LODASH-73638](https://snyk.io/vuln/SNYK-JS-LODASH-73638) |  Yes  | No Known Exploit 
![medium severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/m.png "medium severity") | Regular Expression Denial of Service (ReDoS) <br/>[SNYK-JS-LODASH-73639](https://snyk.io/vuln/SNYK-JS-LODASH-73639) |  Yes  | No Known Exploit 
![low severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/l.png "low severity") | Regular Expression Denial of Service (ReDoS) <br/>[npm:debug:20170905](https://snyk.io/vuln/npm:debug:20170905) |  Yes  | No Known Exploit 
![high severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/h.png "high severity") | Insecure Defaults <br/>[npm:engine.io-client:20160426](https://snyk.io/vuln/npm:engine.io-client:20160426) |  No  | No Known Exploit 
![high severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/h.png "high severity") | Regular Expression Denial of Service (ReDoS) <br/>[npm:fresh:20170908](https://snyk.io/vuln/npm:fresh:20170908) |  No  | No Known Exploit 
![medium severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/m.png "medium severity") | Prototype Pollution <br/>[npm:lodash:20180130](https://snyk.io/vuln/npm:lodash:20180130) |  Yes  | No Known Exploit 
![low severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/l.png "low severity") | Regular Expression Denial of Service (ReDoS) <br/>[npm:mime:20170907](https://snyk.io/vuln/npm:mime:20170907) |  No  | No Known Exploit 
![high severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/h.png "high severity") | Regular Expression Denial of Service (DoS) <br/>[npm:minimatch:20160620](https://snyk.io/vuln/npm:minimatch:20160620) |  Yes  | No Known Exploit 
![medium severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/m.png "medium severity") | Regular Expression Denial of Service (ReDoS) <br/>[npm:ms:20151024](https://snyk.io/vuln/npm:ms:20151024) |  No  | No Known Exploit 
![low severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/l.png "low severity") | Regular Expression Denial of Service (ReDoS) <br/>[npm:ms:20170412](https://snyk.io/vuln/npm:ms:20170412) |  No  | No Known Exploit 
![high severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/h.png "high severity") | Regular Expression Denial of Service (DoS) <br/>[npm:negotiator:20160616](https://snyk.io/vuln/npm:negotiator:20160616) |  No  | No Known Exploit 
![high severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/h.png "high severity") | Prototype Override Protection Bypass <br/>[npm:qs:20170213](https://snyk.io/vuln/npm:qs:20170213) |  No  | No Known Exploit 
![medium severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/m.png "medium severity") | Remote Memory Exposure <br/>[npm:ws:20160104](https://snyk.io/vuln/npm:ws:20160104) |  No  | No Known Exploit 
![high severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/h.png "high severity") | Denial of Service (DoS) <br/>[npm:ws:20160624](https://snyk.io/vuln/npm:ws:20160624) |  No  | No Known Exploit 
![medium severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/m.png "medium severity") | Insecure Randomness <br/>[npm:ws:20160920](https://snyk.io/vuln/npm:ws:20160920) |  No  | No Known Exploit 
![high severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/h.png "high severity") | Denial of Service (DoS) <br/>[npm:ws:20171108](https://snyk.io/vuln/npm:ws:20171108) |  No  | Mature 




<details>
  <summary><b>Commit messages</b></summary>
  </br>
  <details>
    <summary>Package name: <b>express</b></summary>
    The new version differs by 218 commits.</br>
    <ul>
      <li><a href="https://github.com/expressjs/express/commit/f974d22c66d3cd91634ddaba1ef8bcaa8e49daf4">f974d22</a> 4.16.0</li>
      <li><a href="https://github.com/expressjs/express/commit/8d4ceb623d8130e9a4ea784bdbe80ecf2d9d51c9">8d4ceb6</a> docs: add more information to installation</li>
      <li><a href="https://github.com/expressjs/express/commit/c0136d8b48dd3526c58b2ad8666fb4b12b55116c">c0136d8</a> Add express.json and express.urlencoded to parse bodies</li>
      <li><a href="https://github.com/expressjs/express/commit/86f5df00ed921a9e3effdc2e08c038e592a3209b">86f5df0</a> deps: serve-static@1.13.0</li>
      <li><a href="https://github.com/expressjs/express/commit/41964580a8869d5f094e7379d5672dd75f8491f9">4196458</a> deps: send@0.16.0</li>
      <li><a href="https://github.com/expressjs/express/commit/ddeb71301c98421e0c3cc9fd43e68fdc9b63a45a">ddeb713</a> tests: add maxAge option tests for res.sendFile</li>
      <li><a href="https://github.com/expressjs/express/commit/715401478516c39ea9b2f855d4109d7d6e1131e0">7154014</a> Add &quot;escape json&quot; setting for res.json and res.jsonp</li>
      <li><a href="https://github.com/expressjs/express/commit/628438d8d890f3707b8eecf57aeff7d0da348e8e">628438d</a> deps: update example dependencies</li>
      <li><a href="https://github.com/expressjs/express/commit/a24fd0ca6cfd29329444fddf678bcdd1c08e56ae">a24fd0c</a> Add options to res.download</li>
      <li><a href="https://github.com/expressjs/express/commit/95fb5cc26848d4c2c57b0a7a74f088538d47d312">95fb5cc</a> perf: remove dead .charset set in res.jsonp</li>
      <li><a href="https://github.com/expressjs/express/commit/44591fee234dd83e05894c5b055703db1f68184c">44591fe</a> deps: vary@~1.1.2</li>
      <li><a href="https://github.com/expressjs/express/commit/2df1ad26a58bf51228d7600df0d62ed17a90ff71">2df1ad2</a> Improve error messages when non-function provided as middleware</li>
      <li><a href="https://github.com/expressjs/express/commit/12c37124689380837b24a7ed962432596237b440">12c3712</a> Use safe-buffer for improved Buffer API</li>
      <li><a href="https://github.com/expressjs/express/commit/fa272edf843a31aa242390d46935437451707d54">fa272ed</a> docs: fix typo in jsdoc comment</li>
      <li><a href="https://github.com/expressjs/express/commit/d9d09b8b9041504b645f3173ca70ef173c7e1563">d9d09b8</a> perf: re-use options object when generating ETags</li>
      <li><a href="https://github.com/expressjs/express/commit/02a9d5fb28e313fd94ee5ec24fe5da02fbc0d6eb">02a9d5f</a> deps: proxy-addr@~2.0.2</li>
      <li><a href="https://github.com/expressjs/express/commit/c2f4fb535688eaec14c713190a4ab881e195a41a">c2f4fb5</a> deps: finalhandler@1.1.0</li>
      <li><a href="https://github.com/expressjs/express/commit/673d51f4f0fa83f6b663ed6f9f0426940d07664b">673d51f</a> deps: utils-merge@1.0.1</li>
      <li><a href="https://github.com/expressjs/express/commit/5cc761c86593f2e87c7a9dac02135548096bb952">5cc761c</a> deps: parseurl@~1.3.2</li>
      <li><a href="https://github.com/expressjs/express/commit/ad7d96db479e6e9d93ab4848d5fe163905e123ed">ad7d96d</a> deps: qs@6.5.1</li>
      <li><a href="https://github.com/expressjs/express/commit/e62bb8bf9f68382414cdd7997fe661de4647c987">e62bb8b</a> deps: etag@~1.8.1</li>
      <li><a href="https://github.com/expressjs/express/commit/70589c3aef6fb64ce396848e78ca7ea0768d2d5d">70589c3</a> deps: content-type@~1.0.4</li>
      <li><a href="https://github.com/expressjs/express/commit/9a99c152703048591c031bd10d2a2e3ca55ebcac">9a99c15</a> deps: accepts@~1.3.4</li>
      <li><a href="https://github.com/expressjs/express/commit/550043c21727674a9d00c30504beb95cfbd7bbba">550043c</a> deps: setprototypeof@1.1.0</li>
    </ul>

   <a href="https://github.com/expressjs/express/compare/193bed2649c55c1fd362e46cd4702c773f3e7434...f974d22c66d3cd91634ddaba1ef8bcaa8e49daf4">See the full diff</a>
  </details>
  <details>
    <summary>Package name: <b>socket.io</b></summary>
    The new version differs by 250 commits.</br>
    <ul>
      <li><a href="https://github.com/socketio/socket.io/commit/3367eaa948a97f32f965da8d2cbe06fdc0b84818">3367eaa</a> [chore] Release 2.0.0</li>
      <li><a href="https://github.com/socketio/socket.io/commit/6c0705f733d813cc5b9faedf5692b9cd10d58e21">6c0705f</a> [docs] Add an example of custom parser (#2929)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/1980fb4a0393e2154c045860ab8bbe0512ad2864">1980fb4</a> [chore] Merge history of 1.7.x and 0.9.x branches (#2930)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/0d07c47f815e2174dcafac29441123682677313c">0d07c47</a> [chore] Added backers and sponsors on the README (#2933)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/a086588747599764ffcfc5d7d0d1adabd4d4e2a9">a086588</a> [chore] Bump dependencies (#2926)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/87b06ad3628650e5d8910c2a107469e9c38328d1">87b06ad</a> [feat] Move binary detection to the parser (#2923)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/199eec648e28cf5bb75e98bd5402ab2641de6624">199eec6</a> [docs] Replace non-breaking space with proper whitespace (#2913)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/f1b39a6b1d0f30c4dce63a6b2a2aa9d839483285">f1b39a6</a> [docs] Update emit cheatsheet (#2906)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/240b154960d89e65ccddddf4319f07e9e63d69b4">240b154</a> [docs] Explicitly document that Server extends EventEmitter (#2874)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/c5b77387309e5231d9e3d6f3974391bef067b874">c5b7738</a> [docs] Add server.engine.generateId attribute (#2880)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/03f3bc9ab3d5093a746b8e434b29dc43106a0804">03f3bc9</a> [docs] Fix wrong space character in README (#2900)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/e40accf7a12f6f04a63739f378e67b2f7fbd3b68">e40accf</a> [docs] Fix documentation for &#x27;connect&#x27; event (#2898)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/01a4623613d9791d1c2043f092c7c25d55c35279">01a4623</a> [feat] Allow to join several rooms at once (#2879)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/2d5b0026c5e472de32234bfc9d5911951f3db579">2d5b002</a> [docs] Add webpack build example (#2828)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/5ae06e6285c53c4e90622c6830bc63950c38269e">5ae06e6</a> [chore] Bump socket.io-adapter to version 1.0.0 (#2867)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/4d8f68c7dc479da8b75cc93001f89ee6e32d3c12">4d8f68c</a> [chore] Bump engine.io to version 2.0.2 (#2864)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/5b79ab1af195f70c46ab1b6c4a1f955f7268a255">5b79ab1</a> [docs] Update the wording to match the code example (#2853)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/54ff591b07ad17915ffd9f325448e72c9a76e828">54ff591</a> [feature] Merge Engine.IO and Socket.IO handshake packets (#2833)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/e1facd5155bac210f287b62290a36b4997df1740">e1facd5</a> [docs] Small addition to the Express Readme Part (#2846)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/3b92cc2b2678f0e102d7a882248424475e7116ae">3b92cc2</a> [feature] Allow the use of custom parsers (#2829)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/3d695c60f136027df1086423e4ff5b68e904804f">3d695c6</a> [chore] Bump engine.io to version 2.0.0 (#2832)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/3b5f4339a7b73c449684707f021c3f4aa2e01b13">3b5f433</a> [fix] Use path.resolve by default and require.resolve as a fallback (#2797)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/23c9dd34d54722dd71f5dd169179c6a02f5c13d3">23c9dd3</a> [docs] Add a &#x27;Features&#x27; section in the README (#2824)</li>
      <li><a href="https://github.com/socketio/socket.io/commit/e28b47542875ddea8d7960423bca503430ee0b4a">e28b475</a> [docs] Add httpd cluster example (#2819)</li>
    </ul>

   <a href="https://github.com/socketio/socket.io/compare/e2ebd4349bf27c3839fc9a2700b42cf8390ac3bd...3367eaa948a97f32f965da8d2cbe06fdc0b84818">See the full diff</a>
  </details>
</details>





Check the changes in this PR to ensure they won't cause issues with your project.



------------



**Note:** *You are seeing this because you or someone else with access to this repository has authorized Snyk to open fix PRs.*

For more information:

🧐 [View latest project report](https://app.snyk.io/org/lukeswitz/project/f4e42c6d-9e22-4645-b4bd-6fc79f6fbd3b)

🛠 [Adjust project settings](https://app.snyk.io/org/lukeswitz/project/f4e42c6d-9e22-4645-b4bd-6fc79f6fbd3b/settings)

📚 [Read more about Snyk's upgrade and patch logic](https://snyk.io/docs/fixing-vulnerabilities/)

[//]: # (snyk:metadata:{"dependencies":[{"name":"express","from":"4.13.4","to":"4.16.0"},{"name":"grunt-cli","from":"0.1.13","to":"1.3.0"},{"name":"socket.io","from":"1.3.7","to":"2.0.0"}],"packageManager":"npm","projectPublicId":"f4e42c6d-9e22-4645-b4bd-6fc79f6fbd3b","projectUrl":"https://app.snyk.io/org/lukeswitz/project/f4e42c6d-9e22-4645-b4bd-6fc79f6fbd3b?utm_source=github&utm_medium=fix-pr","type":"user-initiated","patch":[],"vulns":["SNYK-JS-LODASH-450202","SNYK-JS-LODASH-73638","SNYK-JS-LODASH-73639","npm:debug:20170905","npm:engine.io-client:20160426","npm:fresh:20170908","npm:lodash:20180130","npm:mime:20170907","npm:minimatch:20160620","npm:ms:20151024","npm:ms:20170412","npm:negotiator:20160616","npm:qs:20170213","npm:ws:20160104","npm:ws:20160624","npm:ws:20160920","npm:ws:20171108"],"upgrade":["SNYK-JS-LODASH-450202","SNYK-JS-LODASH-73638","SNYK-JS-LODASH-73639","npm:debug:20170905","npm:engine.io-client:20160426","npm:fresh:20170908","npm:lodash:20180130","npm:mime:20170907","npm:minimatch:20160620","npm:ms:20151024","npm:ms:20170412","npm:negotiator:20160616","npm:qs:20170213","npm:ws:20160104","npm:ws:20160624","npm:ws:20160920","npm:ws:20171108"],"isBreakingChange":true,"env":"prod","prType":"fix","templateVariants":[]})
