### PR TITLE
Distribution security/package updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 
@@ -43,7 +43,7 @@ allprojects {
         // these are common variables used in */build.gradle
         version_number = getVersionName()
         group_info = "haven"
-        buildToolsVersion = "29.0.2"
+        buildToolsVersion = "30.0.2"
         minSdkVersion = 16
         targetSdkVersion = 29
     }
@@ -58,8 +58,8 @@ allprojects {
 
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion = '29.0.2'
+    compileSdkVersion 30
+    buildToolsVersion = '30.0.2'
 
     packagingOptions {
         exclude 'META-INF/LICENSE.txt'
@@ -83,7 +83,7 @@ android {
         versionName getVersionName()
         archivesBaseName = "Haven-$versionName"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 30
         compileOptions {
             sourceCompatibility JavaVersion.VERSION_1_8
             targetCompatibility JavaVersion.VERSION_1_8
@@ -142,13 +142,13 @@ configurations {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta4'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
     implementation "androidx.coordinatorlayout:coordinatorlayout:1.1.0"
     implementation 'androidx.preference:preference:1.1.1'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.android.material:material:1.2.0-alpha06'
+    implementation 'com.google.android.material:material:1.3.0-alpha02'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.wdullaer:materialdatetimepicker:4.2.3'
     implementation 'com.github.guardianproject:signal-cli-android:v0.6.0-android-beta-1'
@@ -180,11 +180,11 @@ dependencies {
     implementation "android.arch.lifecycle:extensions:2.1.0"
 
     testImplementation 'junit:junit:4.13'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test:core:1.2.0'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.2.0'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test:core:1.3.0'
+    androidTestImplementation 'androidx.test:rules:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.3.0'
     androidTestImplementation "android.arch.persistence.room:testing:2.1.0"
 
     // android-job

--- a/docs/preso/plugin/multiplex/package.json
+++ b/docs/preso/plugin/multiplex/package.json
@@ -10,10 +10,10 @@
     "node": "~4.1.1"
   },
   "dependencies": {
-    "express": "~4.13.3",
-    "grunt-cli": "~0.1.13",
-    "mustache": "~2.2.1",
-    "socket.io": "~1.3.7"
+    "express": "~4.17.1",
+    "grunt-cli": "~1.3.0",
+    "mustache": "~2.3.2",
+    "socket.io": "~2.3.0"
   },
   "license": "MIT"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,8 @@
-#Sat Dec 07 05:36:14 EST 2019
+#Fri Sep 11 08:49:28 MDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-rc-3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
 android.useAndroidX=true
 android.enableD8=true


### PR DESCRIPTION
Addresses 19 vulnerabilities via 41 paths including two vulnerable to Prototype Pollution with active proof of concepts: introduced in reveal-js-multiplex@1.0 





