### PR TITLE
Update build to Android Studio 4.2c5 & stuff

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,14 @@
 buildscript {
-    ext.kotlin_version = '1.3.72'
+    ext.kotlin_version = '1.4-M3'
     repositories {
         google()
         jcenter()
+        maven {
+            url "https://dl.bintray.com/kotlin/kotlin-eap/"
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.2.0-alpha05'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 
@@ -36,6 +39,9 @@ repositories {
     jcenter()
     maven { url 'https://github.com/FireZenk/maven-repo/raw/master/' }
     maven { url 'https://jitpack.io' }
+    maven {
+        url "https://dl.bintray.com/kotlin/kotlin-eap/"
+    }
 }
 
 allprojects {
@@ -59,7 +65,7 @@ allprojects {
 
 android {
     compileSdkVersion 29
-    buildToolsVersion = '29.0.2'
+    buildToolsVersion = '29.0.3'
 
     packagingOptions {
         exclude 'META-INF/LICENSE.txt'
@@ -91,8 +97,8 @@ android {
         multiDexEnabled true
         vectorDrawables.useSupportLibrary = true
 
-     //   renderscriptTargetApi 16
-     //   renderscriptSupportModeEnabled true
+        //   renderscriptTargetApi 16
+        //   renderscriptSupportModeEnabled true
 
         ndk {
             abiFilters "armeabi", "armeabi-v7a", "x86", 'arm64-v8a'
@@ -122,8 +128,8 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    
-     kotlinOptions {
+
+    kotlinOptions {
         jvmTarget = "1.8"
     }
 
@@ -143,12 +149,12 @@ configurations {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta4'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta8'
     implementation "androidx.coordinatorlayout:coordinatorlayout:1.1.0"
-    implementation 'androidx.preference:preference:1.1.1'
+    implementation 'androidx.preference:preference-ktx:1.1.1'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.android.material:material:1.2.0-alpha06'
+    implementation 'com.google.android.material:material:1.3.0-alpha01'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.wdullaer:materialdatetimepicker:4.2.3'
     implementation 'com.github.guardianproject:signal-cli-android:v0.6.0-android-beta-1'
@@ -161,7 +167,7 @@ dependencies {
     implementation 'com.facebook.fresco:fresco:2.0.0'
     implementation 'com.github.derlio:audio-waveform:v1.0.1'
     implementation 'com.maxproj.simplewaveform:app:1.0.0'
-    implementation 'com.googlecode.libphonenumber:libphonenumber:8.11.1'
+    implementation 'com.googlecode.libphonenumber:libphonenumber:8.12.6'
     implementation('com.mikepenz:aboutlibraries:7.0.3@aar') {
         transitive = true
     }
@@ -174,11 +180,16 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     // Room
-    implementation "android.arch.persistence.room:runtime:2.1.0"
-    kapt "android.arch.persistence.room:compiler:2.1.0"
+
+    implementation "androidx.room:room-runtime:2.2.5"
+    kapt "androidx.room:room-compiler:2.2.5"
+    implementation "androidx.room:room-ktx:2.2.5"
+
     implementation "android.arch.lifecycle:runtime:2.1.0"
     implementation "android.arch.lifecycle:extensions:2.1.0"
 
+    // Test helpers
+    testImplementation "androidx.room:room-testing:2.2.5"
     testImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:core:1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,6 @@ allprojects {
 
 android {
     compileSdkVersion 29
-    buildToolsVersion = '29.0.3'
 
     packagingOptions {
         exclude 'META-INF/LICENSE.txt'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,6 +3,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-rc-3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-rc-2-all.zip
 android.useAndroidX=true
 android.enableD8=true


### PR DESCRIPTION
Just a quick update to the latest version of AS 4.2 canary 5, updated libraries, updated gradle, kotlin, etc.

Seems to build and passes tests.  But of course try it out.

Did not update build target to 30 as the storage access framework hasn't been updated yet.