### PR TITLE
Use device preferred orientation; fix #439

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -64,11 +64,11 @@
             android:theme="@style/SettingsTheme" />
         <activity
             android:name=".ui.PPAppIntro"
-            android:screenOrientation="fullSensor" />
+            android:screenOrientation="fullUser" />
         <activity
             android:name=".MonitorActivity"
             android:label="@string/app_name"
-            android:screenOrientation="fullSensor"
+            android:screenOrientation="fullUser"
             android:launchMode="singleTop"
             android:resizeableActivity="true"
             android:supportsPictureInPicture="true"
@@ -114,7 +114,7 @@
             android:configChanges="orientation|screenSize|keyboardHidden" />
         <activity
             android:name=".ui.CameraConfigureActivity"
-            android:screenOrientation="fullSensor"
+            android:screenOrientation="fullUser"
             android:configChanges="orientation|screenSize|keyboardHidden" />
 
         <receiver android:name=".sensors.PowerConnectionReceiver">


### PR DESCRIPTION
Address camera sens/monitor overriding device sensor settings in CameraView instances 

Edit: `fullSensor` vs `fullUser`: Use device sensor regardless vs. orientation data digestible, rotation respects native user settings. 