### PR TITLE
Get haven building again! Update libraries, gradle, etc.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,15 @@
 buildscript {
-    ext.kotlin_version = '1.5.21'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
+        mavenCentral()
         jcenter()
-
         maven {
             url "https://dl.bintray.com/kotlin/kotlin-eap/"
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 
@@ -37,6 +37,7 @@ apply plugin: 'kotlin-kapt'
 
 repositories {
     google()
+    mavenCentral()
     jcenter()
     maven { url 'https://jitpack.io' }
     maven {
@@ -64,28 +65,17 @@ allprojects {
 
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     buildToolsVersion = '30.0.3'
 
     buildFeatures {
         viewBinding true
     }
-
     packagingOptions {
-        exclude 'META-INF/LICENSE.txt'
-        exclude 'META-INF/NOTICE.txt'
-        exclude 'META-INF/DEPENDENCIES'
-        exclude 'META-INF/NOTICE'
-        exclude 'META-INF/LICENSE'
-        exclude 'META-INF/LICENSE.txt'
-        exclude 'META-INF/NOTICE.txt'
+        resources {
+            excludes += ['META-INF/LICENSE.txt', 'META-INF/NOTICE.txt', 'META-INF/DEPENDENCIES', 'META-INF/NOTICE', 'META-INF/LICENSE', 'META-INF/LICENSE.txt', 'META-INF/NOTICE.txt']
+        }
     }
-
-    dexOptions {
-        javaMaxHeapSize "2g"
-        preDexLibraries true
-    }
-
 
     defaultConfig {
         applicationId "org.havenapp.main"
@@ -93,12 +83,12 @@ android {
         versionName getVersionName()
         archivesBaseName = "Haven-$versionName"
         minSdkVersion 16
-        targetSdkVersion 30
-        ndkVersion '21.3.6528147'
+        targetSdkVersion 33
+        ndkVersion '25.0.8775105'
         //ndkPath '/home/n8fr8/Android/Ndk'
         compileOptions {
-            sourceCompatibility JavaVersion.VERSION_1_8
-            targetCompatibility JavaVersion.VERSION_1_8
+            sourceCompatibility JavaVersion.VERSION_11
+            targetCompatibility JavaVersion.VERSION_11
         }
         multiDexEnabled true
         vectorDrawables.useSupportLibrary = true
@@ -139,14 +129,15 @@ android {
         jvmTarget = "1.8"
     }
 
-    lintOptions {
-        checkReleaseBuilds false
-        abortOnError false
-    }
 
     sourceSets {
         androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
     }
+    lint {
+        abortOnError false
+        checkReleaseBuilds false
+    }
+    namespace 'org.havenapp.main'
 }
 
 configurations {
@@ -154,14 +145,14 @@ configurations {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
-    implementation "androidx.coordinatorlayout:coordinatorlayout:1.1.0"
-    implementation 'androidx.preference:preference-ktx:1.1.1'
+    implementation 'androidx.appcompat:appcompat:1.4.2'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation "androidx.coordinatorlayout:coordinatorlayout:1.2.0"
+    implementation 'androidx.preference:preference-ktx:1.2.0'
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'androidx.annotation:annotation:1.2.0'
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'androidx.annotation:annotation:1.4.0'
+    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'com.wdullaer:materialdatetimepicker:4.2.3'
     implementation 'com.github.guardianproject:signal-cli-android:v0.6.0-android-beta-1'
     implementation 'net.the4thdimension:audio-wife:1.0.3'
@@ -170,10 +161,11 @@ dependencies {
     implementation 'org.nanohttpd:nanohttpd-webserver:2.3.1'
     implementation 'me.angrybyte.picker:picker:1.3.1'
     implementation 'com.github.stfalcon:frescoimageviewer:0.5.0'
-    implementation 'com.facebook.fresco:fresco:2.0.0'
+    implementation 'com.facebook.fresco:fresco:2.6.0'
+    implementation "com.facebook.infer.annotation:infer-annotation:0.18.0"
     implementation 'com.github.derlio:audio-waveform:v1.0.1'
     implementation 'com.maxproj.simplewaveform:app:1.0.0'
-    implementation 'com.googlecode.libphonenumber:libphonenumber:8.12.24'
+    implementation 'com.googlecode.libphonenumber:libphonenumber:8.12.51'
     implementation('com.mikepenz:aboutlibraries:7.0.3@aar') {
         transitive = true
     }
@@ -182,34 +174,34 @@ dependencies {
     implementation 'com.github.ybq:Android-SpinKit:1.4.0'
     implementation 'io.github.silvaren:easyrs:0.5.3'
     // jcodec's pure-java video coding replaced by android system encoding
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.5.21"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.7.10"
 
     // Room
 
-    implementation "androidx.room:room-runtime:2.3.0"
-    kapt "androidx.room:room-compiler:2.3.0"
-    implementation "androidx.room:room-ktx:2.3.0"
+    implementation "androidx.room:room-runtime:2.4.2"
+    kapt "androidx.room:room-compiler:2.4.2"
+    implementation "androidx.room:room-ktx:2.4.2"
 
 
     implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
-    implementation "androidx.lifecycle:lifecycle-common-java8:2.3.1"
+    implementation "androidx.lifecycle:lifecycle-common-java8:2.5.0"
 
 
     // Test helpers
-    testImplementation "androidx.room:room-testing:2.3.0"
+    testImplementation "androidx.room:room-testing:2.4.2"
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:core:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.4.0'
-    androidTestImplementation "androidx.room:room-testing:2.3.0"
+    androidTestImplementation "androidx.room:room-testing:2.4.2"
 
     // android-job
-    implementation 'com.evernote:android-job:1.4.2'
+    implementation 'com.evernote:android-job:1.4.3'
 
     // new camera view: https://github.com/natario1/CameraView
-    implementation 'com.otaliastudios:cameraview:2.6.4'
+    implementation 'com.otaliastudios:cameraview:2.7.2'
 
 
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,6 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.7.1-all.zip
-android.useAndroidX=true
-android.enableD8=true
+distributionUrl=https://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="org.havenapp.main">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
@@ -47,6 +46,7 @@
         tools:ignore="GoogleAppIndexingWarning"
         android:requestLegacyExternalStorage="true">
         <activity
+            android:exported="true"
             android:name=".ListActivity"
             android:configChanges="orientation|screenSize"
             android:label="@string/title_activity_start"
@@ -117,7 +117,8 @@
             android:screenOrientation="fullUser"
             android:configChanges="orientation|screenSize|keyboardHidden" />
 
-        <receiver android:name=".sensors.PowerConnectionReceiver">
+        <receiver android:name=".sensors.PowerConnectionReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.ACTION_POWER_CONNECTED" />
                 <action android:name="android.intent.action.ACTION_POWER_DISCONNECTED" />


### PR DESCRIPTION
Not really tested, but it builds in AS 2022.1.1 c8 targeting sdk 33

Mostly updates to libraries and gradle and some new requirements in the manifest. To address a warning in updated fresco 2.6.0 had to add new dependency:

"com.facebook.infer.annotation:infer-annotation:0.18.0"

Again, I didn't test this really.  That's important to emphasize.  But it built fine and I was able to run it on a device (api 32) and the emulator (api 16) and flip back and forth between screens and stuff.

Inspired by issue #456